### PR TITLE
Feature: copy repo hooks on init

### DIFF
--- a/tests/commands/test_init.py
+++ b/tests/commands/test_init.py
@@ -1,10 +1,17 @@
+import glob
+import os
+import pathlib
+import shutil
 from contextlib import contextmanager
 from types import SimpleNamespace
+from unittest import TestCase
+from unittest.mock import MagicMock
 from unittest.mock import Mock
 
 import pytest
-
-from gh_worktree.commands.init import InitCommand, RepositoryTarget, normalize
+from gh_worktree.commands.init import InitCommand
+from gh_worktree.commands.init import normalize
+from gh_worktree.commands.init import RepositoryTarget
 from gh_worktree.hooks import Hook
 
 
@@ -23,65 +30,145 @@ class StubContext:
             self.cwd = old_cwd
 
 
-def test_normalize_owner_repo():
+def test_normalize__owner_repo():
     assert normalize("octo/repo") == "https://github.com/octo/repo.git"
 
 
-def test_normalize_invalid_repo():
+def test_normalize__no_dot_git():
+    assert (
+        normalize("https://github.com/octo/repo") == "https://github.com/octo/repo.git"
+    )
+
+
+def test_normalize__ssh():
+    assert normalize("git@github.com:octo/repo.git") == "git@github.com:octo/repo.git"
+
+
+def test_normalize__invalid_repo():
     with pytest.raises(ValueError, match="Invalid repository path format"):
         normalize("not a repo")
 
 
-def test_repository_target_parses_ssh_uri():
-    target = RepositoryTarget("git@github.com:octo/repo.git")
-    assert target.path == "octo/repo.git"
-    assert target.owner == "octo"
-    assert target.name == "repo"
+class RepositoryTargetTestCase(TestCase):
+    def test_validate(self):
+        target = RepositoryTarget("https://github.com/octo/repo.git")
+        target.validate()
+
+    def test_validate__invalid_path(self):
+        target = RepositoryTarget("https://github.com/octo/repo/pull/123.git")
+        with self.assertRaises(
+            ValueError, msg="Invalid repository path: octo/repo/pull/123"
+        ):
+            target.validate()
+
+    def test_path__url(self):
+        target = RepositoryTarget("https://github.com/octo/repo.git")
+        self.assertEqual(target.path, "octo/repo.git")
+
+    def test_path__ssh(self):
+        target = RepositoryTarget("git@github.com:octo/repo.git")
+        self.assertEqual(target.path, "octo/repo.git")
+
+    def test_path__owner_repo(self):
+        target = RepositoryTarget("octo/repo")
+        self.assertEqual(target.path, "octo/repo.git")
+
+    def test_owner(self):
+        target = RepositoryTarget("https://github.com/octo/repo.git")
+        self.assertEqual(target.owner, "octo")
+
+    def test_repo(self):
+        target = RepositoryTarget("https://github.com/octo/repo.git")
+        self.assertEqual(target.name, "repo")
+
+    def test_destination_dir__default(self):
+        target = RepositoryTarget("octo/repo")
+        self.assertEqual(target.destination_dir, "repo")
+
+    def test_destination_dir__custom(self):
+        target = RepositoryTarget("octo/repo", destination_dir="custom-dir")
+        self.assertEqual(target.destination_dir, "custom-dir")
 
 
-def test_init_command_writes_gitdir_and_config(tmp_path):
-    project_dir = tmp_path / "project"
-    config_dir = tmp_path / "config"
-    context = StubContext(tmp_path, config_dir)
+class InitCommandTestCase(TestCase):
+    @pytest.fixture(autouse=True)
+    def prepare_fixture(self, tmp_path):
+        self.tmp_path = tmp_path
 
-    hooks = SimpleNamespace(fire=Mock())
-    git = SimpleNamespace(clone=Mock(), config=Mock(), fetch=Mock())
-    gh = SimpleNamespace(
-        repo_status=Mock(
-            return_value={
-                "defaultBranchRef": {"name": "main"},
-                "owner": {"login": "octo"},
-                "name": "repo",
-                "url": "https://github.com/octo/repo",
-                "isPrivate": False,
-            }
+    def setUp(self):
+        self.project_dir = pathlib.Path("project")
+        self.config_dir = self.tmp_path / ".gh" / "worktree"
+        self.context = StubContext(self.tmp_path, self.config_dir)
+
+        self.hooks = SimpleNamespace(fire=Mock(), add=MagicMock())
+        self.git = SimpleNamespace(
+            clone=Mock(),
+            config=Mock(),
+            fetch=Mock(),
+            ls_tree=Mock(return_value=iter([])),
+            cat_file=Mock(return_value=iter([])),
         )
-    )
-    runtime = SimpleNamespace(context=context, hooks=hooks, git=git, gh=gh)
+        self.gh = SimpleNamespace(
+            repo_status=Mock(
+                return_value={
+                    "defaultBranchRef": {"name": "main"},
+                    "owner": {"login": "octo"},
+                    "name": "repo",
+                    "url": "https://github.com/octo/repo",
+                    "isPrivate": False,
+                }
+            )
+        )
+        self.runtime = SimpleNamespace(
+            context=self.context, hooks=self.hooks, git=self.git, gh=self.gh
+        )
 
-    command = InitCommand(runtime)
-    command("octo/repo", str(project_dir))
+    def tearDown(self):
+        for file_path in glob.glob("*", root_dir=self.tmp_path):
+            shutil.rmtree(os.path.join(self.tmp_path, file_path))
 
-    git.clone.assert_called_once_with("https://github.com/octo/repo.git", ".bare")
-    git.config.assert_called_once_with(
-        "remote.origin.fetch", "+refs/heads/*:refs/remotes/origin/*"
-    )
-    git.fetch.assert_called_once_with()
+    def test_call__basic(self):
+        command = InitCommand(self.runtime)
+        command("octo/repo", str(self.project_dir))
 
-    gitdir_file = project_dir / ".git"
-    assert gitdir_file.read_text() == "gitdir: ./.bare"
-    config_file = config_dir / "config.json"
-    assert config_file.exists()
+        self.git.clone.assert_called_once_with(
+            "https://github.com/octo/repo.git", ".bare"
+        )
+        self.git.config.assert_called_once_with(
+            "remote.origin.fetch", "+refs/heads/*:refs/remotes/origin/*"
+        )
+        self.git.fetch.assert_called_once_with()
 
-    hooks.fire.assert_any_call(
-        Hook.pre_init,
-        "https://github.com/octo/repo.git",
-        str(project_dir),
-        skip_project=True,
-    )
-    hooks.fire.assert_any_call(
-        Hook.post_init,
-        "https://github.com/octo/repo.git",
-        str(project_dir),
-        skip_project=True,
-    )
+        gitdir_file = self.tmp_path / self.project_dir / ".git"
+        assert gitdir_file.read_text() == "gitdir: ./.bare"
+        config_file = self.config_dir / "config.json"
+        assert config_file.exists()
+
+        self.hooks.fire.assert_any_call(
+            Hook.pre_init,
+            "https://github.com/octo/repo.git",
+            str(self.tmp_path / self.project_dir),
+            skip_project=True,
+        )
+        self.hooks.fire.assert_any_call(
+            Hook.post_init,
+            "https://github.com/octo/repo.git",
+            str(self.tmp_path / self.project_dir),
+        )
+
+    def test_call__installs_hooks(self):
+
+        def ls_tree_side_effect(branch, path):
+            if path.endswith("post_checkout"):
+                return iter(["100755 blob ...    post_checkout"])
+            return iter([])
+
+        self.git.ls_tree.side_effect = ls_tree_side_effect
+        self.git.cat_file.return_value = iter(["echo 'hello'"])
+
+        mock_f = self.runtime.hooks.add.return_value.__enter__.return_value
+
+        command = InitCommand(self.runtime)
+        command("octo/repo", str(self.project_dir))
+
+        mock_f.write.assert_called_once_with("echo 'hello'\n")

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -1,85 +1,124 @@
+import glob
 import hashlib
 import os
+import shutil
 import stat
+from unittest import mock
+from unittest import TestCase
 
 import pytest
-
-from gh_worktree.config import GlobalConfig
-from gh_worktree.hooks import Hook, Hooks
-
-
-class StubContext:
-    def __init__(self, global_config, global_config_dir, config_dir, cwd):
-        self._global_config = global_config
-        self.global_config_dir = global_config_dir
-        self.config_dir = config_dir
-        self.cwd = cwd
-        self.set_config_called = False
-
-    def get_global_config(self):
-        return self._global_config
-
-    def set_config(self, config):
-        self.set_config_called = True
+from gh_worktree.context import Context
+from gh_worktree.hooks import Hook
+from gh_worktree.hooks import HookExists
+from gh_worktree.hooks import Hooks
 
 
-def test_check_allowed_existing_hook(tmp_path, monkeypatch):
-    hook_file = tmp_path / "pre_init"
-    hook_file.write_bytes(b"echo ok")
-    checksum = hashlib.sha256(hook_file.read_bytes()).hexdigest()
+class HooksTestCase(TestCase):
+    @pytest.fixture(autouse=True)
+    def prepare_fixture(self, tmp_path):
+        self.tmp_path = tmp_path
 
-    global_config = GlobalConfig()
-    global_config.allow_hook(str(hook_file), checksum)
-    context = StubContext(global_config, str(tmp_path), str(tmp_path), str(tmp_path))
+    def setUp(self):
+        self.context = Context()
+        self.context.cwd = str(self.tmp_path)
+        self.hooks_path = self.tmp_path / ".gh" / "worktree" / "hooks"
+        os.makedirs(self.tmp_path / ".bare")
+        os.makedirs(self.context.config_dir)
+        self.hooks_path.mkdir()
 
-    monkeypatch.setattr(
-        "builtins.input", lambda _: pytest.fail("input should not be called")
-    )
+        self.hooks = Hooks(self.context)
 
-    hooks = Hooks(context)
-    assert hooks._check_allowed(str(hook_file)) is True
-    assert context.set_config_called is False
+    def tearDown(self):
+        for file_path in glob.glob("*", root_dir=self.tmp_path):
+            shutil.rmtree(os.path.join(self.tmp_path, file_path))
 
+    @mock.patch("gh_worktree.hooks.input")
+    def test_check_allowed__existing_hook(self, mock_input):
+        global_config = self.context.get_global_config()
 
-def test_check_allowed_prompts_and_saves(tmp_path, monkeypatch):
-    hook_file = tmp_path / "pre_init"
-    hook_file.write_bytes(b"echo ok")
+        hook_file = self.hooks_path / Hook.pre_init.name
+        hook_file.write_bytes(b"echo ok")
+        checksum = hashlib.sha256(hook_file.read_bytes()).hexdigest()
 
-    global_config = GlobalConfig()
-    context = StubContext(global_config, str(tmp_path), str(tmp_path), str(tmp_path))
+        global_config.allow_hook(str(hook_file), checksum)
+        self.context.set_config(global_config)
 
-    monkeypatch.setattr("builtins.input", lambda _: "y")
+        self.assertTrue(self.hooks._check_allowed(str(hook_file)))
 
-    hooks = Hooks(context)
-    assert hooks._check_allowed(str(hook_file)) is True
-    assert context.set_config_called is True
-    assert str(hook_file) in global_config.allowed_hooks
+        mock_input.assert_not_called()
+        global_config = self.context.get_global_config()
+        self.assertEqual(global_config.allowed_hooks[str(hook_file)], checksum)
 
+    @mock.patch("gh_worktree.hooks.input")
+    def test_check_allowed__prompts_and_saves(self, mock_input):
+        hook_file = self.hooks_path / Hook.pre_init.name
+        hook_file.write_bytes(b"echo ok")
+        checksum = hashlib.sha256(hook_file.read_bytes()).hexdigest()
 
-def test_fire_runs_hook_when_allowed(tmp_path, monkeypatch):
-    hooks_dir = tmp_path / "hooks"
-    hooks_dir.mkdir()
-    hook_file = hooks_dir / Hook.pre_init.name
-    hook_file.write_text("#!/bin/sh\n")
-    # Make the hook file executable
-    hook_file.chmod(hook_file.stat().st_mode | stat.S_IEXEC)
+        mock_input.return_value = "y"
 
-    project_dir = tmp_path / "project"
-    project_dir.mkdir()
-    context = StubContext(
-        GlobalConfig(), str(tmp_path), str(project_dir), str(tmp_path)
-    )
-    hooks = Hooks(context)
+        self.assertTrue(self.hooks._check_allowed(str(hook_file)))
 
-    monkeypatch.setattr(hooks, "_check_allowed", lambda _: True)
+        mock_input.assert_called_once()
+        global_config = self.context.get_global_config()
+        self.assertEqual(global_config.allowed_hooks[str(hook_file)], checksum)
 
-    calls = []
+    @mock.patch("gh_worktree.hooks.Hooks._check_allowed")
+    @mock.patch("gh_worktree.hooks.stream_exec")
+    def test_fire__allowed(self, mock_stream_exec, mock_check_allowed):
+        hook_file = self.hooks_path / Hook.pre_init.name
+        hook_file.write_bytes(b"echo ok")
+        # Make the hook file executable
+        hook_file.chmod(hook_file.stat().st_mode | stat.S_IEXEC)
 
-    def fake_stream_exec(command, cwd):
-        calls.append((command, cwd))
-        return 0
+        mock_check_allowed.return_value = True
+        mock_stream_exec.return_value = 0
 
-    monkeypatch.setattr("gh_worktree.hooks.stream_exec", fake_stream_exec)
+        self.assertTrue(self.hooks.fire(Hook.pre_init, "arg1"))
+        mock_stream_exec.assert_called_once_with(
+            [str(hook_file), "arg1"], cwd=str(self.tmp_path)
+        )
 
-    assert hooks.fire(Hook.pre_init, "arg1") is True
-    assert calls == [([str(hook_file), "arg1"], str(tmp_path))]
+    @mock.patch("gh_worktree.hooks.Hooks._check_allowed")
+    @mock.patch("gh_worktree.hooks.stream_exec")
+    def test_fire__not_executable(self, mock_stream_exec, mock_check_allowed):
+        hook_file = self.hooks_path / Hook.pre_init.name
+        hook_file.write_bytes(b"echo ok")
+        hook_file.chmod(stat.S_IREAD)
+
+        mock_check_allowed.return_value = True
+        mock_stream_exec.return_value = 0
+
+        self.assertFalse(self.hooks.fire(Hook.pre_init, "arg1"))
+        mock_stream_exec.assert_not_called()
+
+    @mock.patch("gh_worktree.hooks.Hooks._check_allowed")
+    @mock.patch("gh_worktree.hooks.stream_exec")
+    def test_fire__disallowed(self, mock_stream_exec, mock_check_allowed):
+        hook_file = self.hooks_path / Hook.pre_init.name
+        hook_file.write_bytes(b"echo ok")
+        # Make the hook file executable
+        hook_file.chmod(hook_file.stat().st_mode | stat.S_IEXEC)
+
+        mock_check_allowed.return_value = False
+        mock_stream_exec.return_value = 0
+
+        self.assertFalse(self.hooks.fire(Hook.pre_init, "arg1"))
+        mock_stream_exec.assert_not_called()
+
+    def test_add(self):
+        with self.hooks.add(Hook.pre_init) as f:
+            f.write("echo ok")
+
+        hook_file = self.hooks_path / Hook.pre_init.name
+        self.assertTrue(hook_file.exists())
+        self.assertEqual(hook_file.read_text(), "echo ok")
+        self.assertTrue(os.access(hook_file, os.X_OK))
+
+    def test_add__existing(self):
+        hook_file = self.hooks_path / Hook.pre_init.name
+        hook_file.write_bytes(b"echo ok")
+
+        with self.assertRaises(HookExists):
+            with self.hooks.add(Hook.pre_init) as f:
+                f.write("echo ok")


### PR DESCRIPTION
## Summary
- Removes automatic chmod for hooks
- Adds ability to define hooks in a repo and copy them on `init`