### PR TITLE
Fix default branch/remote pathway

### DIFF
--- a/src/gh_worktree/commands/create.py
+++ b/src/gh_worktree/commands/create.py
@@ -40,10 +40,9 @@ class CreateCommand(Command):
             git_remote_name, base_ref = base_ref.split("/", 1)
 
         if git_remote_name is None:
-            git_remote = self._runtime.get_remote()
+            git_remote = self._runtime.get_default_remote()
             git_remote_name = git_remote.name
 
-        # self._runtime.git.fetch(git_remote_name, f"{base_ref}:{base_ref}")
         self._runtime.git.fetch(git_remote_name)
 
         normalized_name = normalize_worktree_name(worktree_name)

--- a/tests/commands/test_create.py
+++ b/tests/commands/test_create.py
@@ -94,6 +94,7 @@ class CreateCommandTestCase(TestCase):
 
         self.assertTrue(self.context.assert_called)
         self.runtime.get_remote.assert_not_called()
+        self.runtime.get_default_remote.assert_not_called()
         self.git.fetch.assert_called_once_with("alt")
         self.git.add_worktree.assert_called_once_with("feature", "alt/dev")
         self.templates.copy.assert_called_once_with("feature")

--- a/tests/commands/test_create.py
+++ b/tests/commands/test_create.py
@@ -39,6 +39,7 @@ class CreateCommandTestCase(TestCase):
             git=self.git,
             templates=self.templates,
             get_remote=Mock(return_value=GitRemote("origin", "uri", "fetch")),
+            get_default_remote=Mock(return_value=GitRemote("upstream", "uri", "fetch")),
         )
         self.command = CreateCommand(self.runtime)
 
@@ -46,40 +47,67 @@ class CreateCommandTestCase(TestCase):
         self.command("feature")
 
         self.assertTrue(self.context.assert_called)
-        self.runtime.get_remote.assert_called_once_with()
-        self.git.fetch.assert_called_once_with("origin")
-        self.git.add_worktree.assert_called_once_with("feature", "origin/main")
+        self.runtime.get_default_remote.assert_called_once_with()
+        self.git.fetch.assert_called_once_with("upstream")
+        self.git.add_worktree.assert_called_once_with("feature", "upstream/main")
         self.templates.copy.assert_called_once_with("feature")
         self.hooks.fire.assert_any_call(
-            Hook.pre_create, "feature", "origin/main", "feature", bypass_allowlist=False
+            Hook.pre_create,
+            "feature",
+            "upstream/main",
+            "feature",
+            bypass_allowlist=False,
         )
         self.hooks.fire.assert_any_call(
             Hook.post_create,
             "feature",
-            "origin/main",
+            "upstream/main",
+            "feature",
+            bypass_allowlist=False,
+        )
+
+    def test_call__uses_default_remote(self):
+        self.command("feature", "release-x")
+
+        self.assertTrue(self.context.assert_called)
+        self.runtime.get_default_remote.assert_called_once_with()
+        self.git.fetch.assert_called_once_with("upstream")
+        self.git.add_worktree.assert_called_once_with("feature", "upstream/release-x")
+        self.templates.copy.assert_called_once_with("feature")
+        self.hooks.fire.assert_any_call(
+            Hook.pre_create,
+            "feature",
+            "upstream/release-x",
+            "feature",
+            bypass_allowlist=False,
+        )
+        self.hooks.fire.assert_any_call(
+            Hook.post_create,
+            "feature",
+            "upstream/release-x",
             "feature",
             bypass_allowlist=False,
         )
 
     def test_call__respects_explicit_remote_and_ref(self):
-        self.command("feature", "upstream/dev")
+        self.command("feature", "alt/dev")
 
         self.assertTrue(self.context.assert_called)
         self.runtime.get_remote.assert_not_called()
-        self.git.fetch.assert_called_once_with("upstream")
-        self.git.add_worktree.assert_called_once_with("feature", "upstream/dev")
+        self.git.fetch.assert_called_once_with("alt")
+        self.git.add_worktree.assert_called_once_with("feature", "alt/dev")
         self.templates.copy.assert_called_once_with("feature")
         self.hooks.fire.assert_any_call(
             Hook.pre_create,
             "feature",
-            "upstream/dev",
+            "alt/dev",
             "feature",
             bypass_allowlist=False,
         )
         self.hooks.fire.assert_any_call(
             Hook.post_create,
             "feature",
-            "upstream/dev",
+            "alt/dev",
             "feature",
             bypass_allowlist=False,
         )
@@ -113,8 +141,16 @@ class CreateCommandTestCase(TestCase):
         self.command("feature", yes=True)
 
         self.hooks.fire.assert_any_call(
-            Hook.pre_create, "feature", "origin/main", "feature", bypass_allowlist=True
+            Hook.pre_create,
+            "feature",
+            "upstream/main",
+            "feature",
+            bypass_allowlist=True,
         )
         self.hooks.fire.assert_any_call(
-            Hook.post_create, "feature", "origin/main", "feature", bypass_allowlist=True
+            Hook.post_create,
+            "feature",
+            "upstream/main",
+            "feature",
+            bypass_allowlist=True,
         )


### PR DESCRIPTION
## Summary
Running `gh-worktree create some-branch` should have been basing the branch off the default remote and default branch of the repo on Github. It was erroring out and this fixes that.

```
Traceback (most recent call last):
  File "__main__.py", line 4, in <module>
  File "gh_worktree/cli.py", line 7, in main
  File "fire/core.py", line 135, in Fire
  File "fire/core.py", line 468, in _Fire
  File "fire/core.py", line 684, in _CallAndUpdateTrace
  File "gh_worktree/commands/create.py", line 40, in __call__
  File "gh_worktree/runtime.py", line 33, in get_remote
ValueError: Must provide either owner_name or name
[PYI-164413:ERROR] Failed to execute script '__main__' due to unhandled exception!
```