### PR TITLE
Modernize linting, formatting, and build tooling

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,5 @@
+# Run this command to always ignore formatting commits in `git blame`
+# git config blame.ignoreRevsFile .git-blame-ignore-revs
+
+# Reformatting and linting updates
+3419e3243665f74371862adafd62b2deedec72e8

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,8 @@ updates:
       interval: "weekly"
       day: "friday"
       time: "00:00"
+    cooldown:
+      default-days: 7
   # Maintain dependencies for Github Actions
   - package-ecosystem: "github-actions"
     directory: "/"
@@ -16,6 +18,8 @@ updates:
       interval: "monthly"
       day: "friday"
       time: "00:00"
+    cooldown:
+      default-days: 7
     groups:
       github:
         patterns:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,9 +32,11 @@ jobs:
         run: |
           set -eo pipefail
           cd dist/
-          echo "WHL_NAME=$(ls *whl)" >> $GITHUB_ENV
-          echo "PEX_NAME=$(ls gh-worktree.pex)" >> $GITHUB_ENV
-          echo "EXE_NAME=$(ls gh-worktree)" >> $GITHUB_ENV
+          {
+            echo "WHL_NAME=$(ls -- *whl)"
+            echo "PEX_NAME=$(ls gh-worktree.pex)"
+            echo "EXE_NAME=$(ls gh-worktree)"
+          } >> "$GITHUB_ENV"
 
       - uses: actions/upload-artifact@v7
         id: artifact-whl-upload-step
@@ -74,10 +76,12 @@ jobs:
         id: asset-list
         run: |
           set -eo pipefail
-          echo "WHL_NAME=$(ls *whl)" >> $GITHUB_ENV
-          echo "WHL_CHECKSUM=$(find ./ -name '*whl' -type f | head -1 | sha256sum | cut -d ' ' -f 1)" >> $GITHUB_ENV
-          echo "PEX_CHECKSUM=$(find ./ -name 'gh-worktree.pex' -type f | head -1 | sha256sum | cut -d ' ' -f 1)" >> $GITHUB_ENV
-          echo "EXE_CHECKSUM=$(find ./ -name 'gh-worktree' -type f | head -1 | sha256sum | cut -d ' ' -f 1)" >> $GITHUB_ENV
+          {
+            echo "WHL_NAME=$(ls -- *whl)"
+            echo "WHL_CHECKSUM=$(find ./ -name '*whl' -type f | head -1 | sha256sum | cut -d ' ' -f 1)"
+            echo "PEX_CHECKSUM=$(find ./ -name 'gh-worktree.pex' -type f | head -1 | sha256sum | cut -d ' ' -f 1)"
+            echo "EXE_CHECKSUM=$(find ./ -name 'gh-worktree' -type f | head -1 | sha256sum | cut -d ' ' -f 1)"
+          } >> "$GITHUB_ENV"
 
       - name: Create PR comment with asset link
         uses: thollander/actions-comment-pull-request@v3

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,3 +15,11 @@ repos:
     rev: 0.11.6
     hooks:
       - id: uv-lock
+  - repo: https://github.com/google/yamlfmt
+    rev: v0.21.0
+    hooks:
+      - id: yamlfmt
+  - repo: https://github.com/rhysd/actionlint
+    rev: v1.7.12
+    hooks:
+      - id: actionlint

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,30 +3,15 @@ repos:
     rev: v5.0.0
     hooks:
       - id: trailing-whitespace
-      - id: debug-statements
       - id: end-of-file-fixer
         exclude: '^.+?\.json.+?\.ya?ml$'
-  - repo: https://github.com/PyCQA/flake8
-    rev: '7.1.2'
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.15.10
     hooks:
-      - id: flake8
-        additional_dependencies: [
-          'flake8-pyproject'
-        ]
-  - repo: https://github.com/asottile/reorder_python_imports
-    rev: v3.16.0
-    hooks:
-      - id: reorder-python-imports
-        language_version: python3
-  - repo: https://github.com/psf/black
-    rev: '24.10.0'
-    hooks:
-      - id: black
-        additional_dependencies: [
-          'click>=8.0.4'
-        ]
+      - id: ruff
+        args: [--fix, --exit-non-zero-on-fix]
+      - id: ruff-format
   - repo: https://github.com/astral-sh/uv-pre-commit
-    # uv version.
-    rev: 0.10.2
+    rev: 0.11.6
     hooks:
       - id: uv-lock

--- a/.yamlfmt
+++ b/.yamlfmt
@@ -1,0 +1,3 @@
+formatter:
+  retain_line_breaks: true
+  eof_newline: true

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ dist/gh-worktree:
 	uv run pyinstaller gh-worktree.spec
 
 dist/gh-worktree.pex:
-	uv tool run pex==2.88.1 -v . -e gh_worktree.cli:main -o dist/gh-worktree.pex
+	uv run pex -v . -e gh_worktree.cli:main -o dist/gh-worktree.pex
 
 build-whl:
 	uv build --wheel --out-dir ./dist

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,14 +6,14 @@ readme = "README.md"
 authors = [
     { name = "Blaine Jester", email = "bjester@quavalent.com" }
 ]
-license = {file = "LICENSE"}
+license = "MIT"
+license-files = ["LICENSE"]
 keywords = ["git", "github", "worktree", "cli", "development"]
 requires-python = ">=3.10"
 classifiers = [
     "Development Status :: 4 - Beta",
     "Environment :: Console",
     "Intended Audience :: Developers",
-    "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gh-worktree"
-version = "0.3.1"
+version = "0.3.2"
 description = "github CLI extension for worktrees"
 readme = "README.md"
 authors = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,8 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Topic :: Software Development :: Version Control :: Git",
     "Topic :: Utilities",
     "Typing :: Typed"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ dev = [
     "exceptiongroup; python_version < '3.11'",
     "prek",
     "pyinstaller",
-    "ruff>=0.15.11",
+    "ruff>=0.15.10",
     "pex>=2.88.1"
 ]
 
@@ -81,3 +81,7 @@ wheel-exclude = [
     "Makefile",
     "tests/"
 ]
+
+# helps to guard against supply chain attacks
+[tool.uv]
+exclude-newer = "7 days"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,8 @@ dev = [
     "pytest>=8.0.0",
     "exceptiongroup; python_version < '3.11'",
     "prek",
-    "pyinstaller"
+    "pyinstaller",
+    "ruff>=0.15.11",
 ]
 
 [build-system]
@@ -50,8 +51,14 @@ build-backend = "uv_build"
 pythonpath = "src"
 testpaths = ["tests"]
 
-[tool.flake8]
-max-line-length = 100
+[tool.ruff]
+line-length = 100
+
+[tool.ruff.lint]
+select = ["E", "W", "F", "I", "T10", "C90", "UP", "B", "A", "PTH"]
+ignore = []
+
+[tool.ruff.lint.mccabe]
 max-complexity = 10
 
 [tool.uv.build-backend]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ dev = [
     "prek",
     "pyinstaller",
     "ruff>=0.15.11",
+    "pex>=2.88.1"
 ]
 
 [build-system]

--- a/src/gh_worktree/__init__.py
+++ b/src/gh_worktree/__init__.py
@@ -1,5 +1,4 @@
-from importlib.metadata import PackageNotFoundError
-from importlib.metadata import version
+from importlib.metadata import PackageNotFoundError, version
 
 try:
     __version__ = version("gh-worktree")

--- a/src/gh_worktree/cli.py
+++ b/src/gh_worktree/cli.py
@@ -1,4 +1,5 @@
 import fire
+
 from gh_worktree.main import WorktreeCommands
 
 

--- a/src/gh_worktree/command.py
+++ b/src/gh_worktree/command.py
@@ -1,17 +1,15 @@
-from typing import List
-
 from gh_worktree.context import Context
 from gh_worktree.runtime import Runtime
 
 
-class BaseCommand(object):
+class BaseCommand:
     def __init__(self):
         pass
 
 
 class Command(BaseCommand):
     _name: str
-    _aliases: List[str] = []
+    _aliases: list[str] = []
 
     def __init__(self, runtime: Runtime):
         super().__init__()

--- a/src/gh_worktree/commands/checkout.py
+++ b/src/gh_worktree/commands/checkout.py
@@ -1,23 +1,19 @@
 import re
 from functools import cached_property
-from typing import Optional
 
 from gh_worktree.command import Command
 from gh_worktree.hooks import Hook
 from gh_worktree.runtime import Runtime
 from gh_worktree.utils import normalize_worktree_name
 
-
 URL_RE = re.compile(r"^https://github\.com/[a-z0-9-]+/[\w.-]+/pull/\d+$", re.IGNORECASE)
 BRANCH_RE = re.compile(r"^[\w.-/]+$", re.IGNORECASE)
 
 
-class CheckoutInput(object):
+class CheckoutInput:
     """Checkout command input abstraction"""
 
-    def __init__(
-        self, runtime: Runtime, branch_or_pr: str, remote_name: Optional[str] = None
-    ):
+    def __init__(self, runtime: Runtime, branch_or_pr: str, remote_name: str | None = None):
         self.runtime = runtime
         self.branch_or_pr = branch_or_pr
         self.remote_name = remote_name
@@ -28,9 +24,7 @@ class CheckoutInput(object):
             and not URL_RE.match(self.branch_or_pr)
             and not BRANCH_RE.match(self.branch_or_pr)
         ):
-            raise ValueError(
-                "Couldn't parse input. Must be branch name, PR number or PR URL."
-            )
+            raise ValueError("Couldn't parse input. Must be branch name, PR number or PR URL.")
 
         if self.remote_name is not None and (
             self.branch_or_pr.isdigit() or URL_RE.match(self.branch_or_pr)
@@ -67,7 +61,7 @@ class CheckoutInput(object):
         return remote.name
 
     @cached_property
-    def pr_number(self) -> Optional[str]:
+    def pr_number(self) -> str | None:
         """The PR number, if applicable"""
         if self.branch_or_pr.isdigit():
             return self.branch_or_pr
@@ -94,9 +88,7 @@ class CheckoutInput(object):
 class CheckoutCommand(Command):
     _name = "checkout"
 
-    def __call__(
-        self, branch_or_pr: str, remote: Optional[str] = None, yes: bool = False
-    ):  # noqa: C901
+    def __call__(self, branch_or_pr: str, remote: str | None = None, yes: bool = False):  # noqa: C901
         """
         Checkout an existing branch or PR as a worktree.
 
@@ -123,15 +115,11 @@ class CheckoutCommand(Command):
         inpt.validate()
 
         if inpt.pr_number:
-            self._runtime.git.fetch(
-                inpt.remote, f"pull/{inpt.pr_number}/head:{inpt.worktree_name}"
-            )
+            self._runtime.git.fetch(inpt.remote, f"pull/{inpt.pr_number}/head:{inpt.worktree_name}")
         else:
             # TODO: is this good to detect if it's local only?
             try:
-                self._runtime.git.fetch(
-                    inpt.remote, f"{inpt.worktree_name}:{inpt.worktree_name}"
-                )
+                self._runtime.git.fetch(inpt.remote, f"{inpt.worktree_name}:{inpt.worktree_name}")
             except RuntimeError:
                 print("Ignoring git fetch error, attempting to open worktree")
                 pass

--- a/src/gh_worktree/commands/create.py
+++ b/src/gh_worktree/commands/create.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 from gh_worktree.command import Command
 from gh_worktree.hooks import Hook
 from gh_worktree.utils import normalize_worktree_name
@@ -8,7 +6,7 @@ from gh_worktree.utils import normalize_worktree_name
 class CreateCommand(Command):
     _name = "create"
 
-    def __call__(self, worktree_name: str, *base_ref: Optional[str], yes: bool = False):
+    def __call__(self, worktree_name: str, *base_ref: str | None, yes: bool = False):
         """
         Create a new worktree in the current project.
 
@@ -55,9 +53,7 @@ class CreateCommand(Command):
                 normalized_name,
                 bypass_allowlist=yes,
             )
-            self._runtime.git.add_worktree(
-                worktree_name, f"{git_remote_name}/{base_ref}"
-            )
+            self._runtime.git.add_worktree(worktree_name, f"{git_remote_name}/{base_ref}")
             self._runtime.templates.copy(worktree_name)
             self._runtime.hooks.fire(
                 Hook.post_create,

--- a/src/gh_worktree/commands/init.py
+++ b/src/gh_worktree/commands/init.py
@@ -1,13 +1,10 @@
 import re
-from typing import Optional
 from urllib import parse
 
 from gh_worktree.command import Command
 from gh_worktree.config import RepositoryConfig
-from gh_worktree.hooks import Hook
-from gh_worktree.hooks import HookExists
+from gh_worktree.hooks import Hook, HookExists
 from gh_worktree.templates import TemplateExists
-
 
 JUST_PATH_RE = re.compile(r"^[\w\-_]+/[\w\-_]+$")
 GIT_EXT_RE = re.compile(r"\.git$")
@@ -25,8 +22,8 @@ def normalize(repo: str):
     return repo
 
 
-class RepositoryTarget(object):
-    def __init__(self, repo: str, destination_dir: Optional[str] = None):
+class RepositoryTarget:
+    def __init__(self, repo: str, destination_dir: str | None = None):
         self.uri = normalize(repo)
         self._destination_dir = destination_dir
 
@@ -63,7 +60,7 @@ class InitCommand(Command):
 
     _name = "init"
 
-    def __call__(self, repo: str, *destination_dir: Optional[str], yes: bool = False):
+    def __call__(self, repo: str, *destination_dir: str | None, yes: bool = False):
         """
         Initialize a project for using gh-worktree with it, by cloning the project and configuring
         it to be a bare git repo.
@@ -111,9 +108,7 @@ class InitCommand(Command):
                 f.write("gitdir: ./.bare")
 
             self._context.reset_properties()
-            self._runtime.git.config(
-                "remote.origin.fetch", "+refs/heads/*:refs/remotes/origin/*"
-            )
+            self._runtime.git.config("remote.origin.fetch", "+refs/heads/*:refs/remotes/origin/*")
             self._runtime.git.fetch()
             repo_data = self._runtime.gh.repo_status()
             config = RepositoryConfig()
@@ -126,9 +121,7 @@ class InitCommand(Command):
             )
 
             self._context.config_dir.mkdir(parents=True, exist_ok=True)
-            with (self._context.config_dir / "config.json").open(
-                "w", encoding="utf-8"
-            ) as f:
+            with (self._context.config_dir / "config.json").open("w", encoding="utf-8") as f:
                 config.save(f)
 
             self._add_templates(config)
@@ -151,9 +144,7 @@ class InitCommand(Command):
             # copy it
             try:
                 with self._runtime.hooks.add(hook) as f:
-                    for line in self._runtime.git.cat_file(
-                        config.default_branch, hook.git_path
-                    ):
+                    for line in self._runtime.git.cat_file(config.default_branch, hook.git_path):
                         f.write(f"{line}\n")
             except HookExists as e:
                 print(f"{str(e)} Skipping")
@@ -168,9 +159,7 @@ class InitCommand(Command):
             # copy it
             try:
                 with self._runtime.templates.add(template_file) as f:
-                    for line in self._runtime.git.cat_file(
-                        config.default_branch, template_file
-                    ):
+                    for line in self._runtime.git.cat_file(config.default_branch, template_file):
                         f.write(f"{line}\n")
             except TemplateExists as e:
                 print(f"{str(e)} Skipping")

--- a/src/gh_worktree/commands/install.py
+++ b/src/gh_worktree/commands/install.py
@@ -3,9 +3,6 @@ import shutil
 import stat
 import sys
 from pathlib import Path
-from typing import List
-from typing import Optional
-from typing import Tuple
 
 from gh_worktree.command import Command
 
@@ -15,7 +12,7 @@ class InstallCommand(Command):
 
     def __call__(
         self,
-        alias: Optional[str] = None,
+        alias: str | None = None,
         gh_ext: bool = False,
         path_bin: bool = False,
         force: bool = False,
@@ -67,9 +64,7 @@ class InstallCommand(Command):
                 Path.home() / "bin",
             ]
 
-            install_dir = next(
-                (d for d in preferred_install_dirs if str(d) in path_dirs), None
-            )
+            install_dir = next((d for d in preferred_install_dirs if str(d) in path_dirs), None)
 
             if not install_dir:
                 print("Could not find a suitable user binary directory in your PATH.")
@@ -82,36 +77,32 @@ class InstallCommand(Command):
     def _run(
         self,
         current_script_path: Path,
-        target_paths: List[Path],
+        target_paths: list[Path],
         should_link: bool,
         force: bool,
     ):
         for target_path in target_paths:
             if target_path.exists() or target_path.is_symlink():
                 if not force:
-                    print(
-                        f"Path already exists, use --force to overwrite: {target_path}"
-                    )
+                    print(f"Path already exists, use --force to overwrite: {target_path}")
                     sys.exit(1)
                 target_path.unlink(True)
 
             target_path.parent.mkdir(parents=True, exist_ok=True)
 
             if should_link:
-                os.symlink(current_script_path, target_path)
+                target_path.symlink_to(current_script_path)
             else:
                 shutil.copy(current_script_path, target_path)
                 target_path.chmod(target_path.stat().st_mode | stat.S_IEXEC)
             print(f"Installed to {target_path}")
 
-    def _ask(self, target_name: str, gh_ext: bool, path_bin: bool) -> Tuple[bool, bool]:
+    def _ask(self, target_name: str, gh_ext: bool, path_bin: bool) -> tuple[bool, bool]:
         # ask user what path they would like to use for installation, without these args
         if not gh_ext and not path_bin:
             print("Tip: Re-run this with --alias to change the name\n")
             print("Which method do you want to use?")
-            print(
-                f"\t1. As a GitHub CLI (gh) extension: gh {target_name.replace('gh-', '')}"
-            )
+            print(f"\t1. As a GitHub CLI (gh) extension: gh {target_name.replace('gh-', '')}")
             print(f"\t2. In your PATH: {target_name}\n")
 
             choice = input("Your choice (1, 2): ")

--- a/src/gh_worktree/config.py
+++ b/src/gh_worktree/config.py
@@ -1,9 +1,7 @@
 import json
-from typing import Dict
-from typing import List
 
 
-class Config(object):
+class Config:
     type: str
 
     def __init__(self):
@@ -29,11 +27,11 @@ class GlobalConfig(Config):
     type: str = "global"
 
     @property
-    def allowed_hooks(self) -> Dict[str, str]:
+    def allowed_hooks(self) -> dict[str, str]:
         return self._data.get("allowed_hooks", {})
 
     @property
-    def allowed_envvars(self) -> List[str]:
+    def allowed_envvars(self) -> list[str]:
         return self._data.get("allowed_envvars", [])
 
     def allow_hook(self, path: str, checksum: str):

--- a/src/gh_worktree/context.py
+++ b/src/gh_worktree/context.py
@@ -1,19 +1,15 @@
 import os
 from contextlib import contextmanager
 from pathlib import Path
-from typing import Optional
-from typing import Union
 
-from gh_worktree.config import Config
-from gh_worktree.config import GlobalConfig
-from gh_worktree.config import RepositoryConfig
+from gh_worktree.config import Config, GlobalConfig, RepositoryConfig
 from gh_worktree.utils import find_up
 
 
-class Context(object):
+class Context:
     def __init__(self):
         self.cwd = Path.cwd()
-        self._cached_project_dir: Optional[Path] = None
+        self._cached_project_dir: Path | None = None
 
     @property
     def project_dir(self) -> Path:
@@ -41,7 +37,7 @@ class Context(object):
             return Path.home() / ".gh" / "worktree"
 
     @contextmanager
-    def use(self, cwd: Union[str, Path]):
+    def use(self, cwd: str | Path):
         old_cwd = self.cwd
         cwd_path = Path(cwd)
         os.chdir(cwd_path)
@@ -59,8 +55,8 @@ class Context(object):
     def assert_within_project(self):
         try:
             find_up(".bare", self.cwd)
-        except RuntimeError:
-            raise AssertionError("Project not found")
+        except RuntimeError as e:
+            raise AssertionError("Project not found") from e
 
     def get_config(self) -> RepositoryConfig:
         file_path = self.config_dir / "config.json"

--- a/src/gh_worktree/gh.py
+++ b/src/gh_worktree/gh.py
@@ -1,12 +1,10 @@
 import json
 import subprocess
-from typing import Optional
-from typing import Union
 
 from gh_worktree.context import Context
 
 
-class GithubCLI(object):
+class GithubCLI:
     def __init__(self, context: Context):
         self.context = context
 
@@ -20,7 +18,7 @@ class GithubCLI(object):
         )
         return result.stdout.strip()
 
-    def pr_status(self, pr_number: Union[int, str], owner_repo: Optional[str] = None):
+    def pr_status(self, pr_number: int | str, owner_repo: str | None = None):
         fields = [
             "number",
             "author",

--- a/src/gh_worktree/git.py
+++ b/src/gh_worktree/git.py
@@ -1,18 +1,15 @@
 import re
 from collections import namedtuple
-from typing import List
-from typing import Optional
 
 from gh_worktree.context import Context
-from gh_worktree.utils import iter_output
-from gh_worktree.utils import stream_exec
+from gh_worktree.utils import iter_output, stream_exec
 
 TYPE_RE = re.compile(r"\((.*)\)")
 
 GitRemote = namedtuple("GitRemote", ["name", "uri", "type"])
 
 
-class GitCLI(object):
+class GitCLI:
     def __init__(self, context: Context):
         self.context = context
 
@@ -24,8 +21,7 @@ class GitCLI(object):
             )
 
     def _iter_output(self, *command: str):
-        for line in iter_output(["git", *command], cwd=self.context.cwd):
-            yield line
+        yield from iter_output(["git", *command], cwd=self.context.cwd)
 
     def clone(self, src: str, destination_dir: str):
         self._stream_exec("clone", "--bare", src, destination_dir)
@@ -34,20 +30,18 @@ class GitCLI(object):
         self._stream_exec("config", config_option, config_value)
 
     def ls_tree(self, branch_name: str, file_path: str):
-        for line in self._iter_output("ls-tree", "-r", branch_name, "--", file_path):
-            yield line
+        yield from self._iter_output("ls-tree", "-r", branch_name, "--", file_path)
 
     def cat_file(self, branch_name: str, file_path: str):
-        for line in self._iter_output("cat-file", "-p", f"{branch_name}:{file_path}"):
-            yield line
+        yield from self._iter_output("cat-file", "-p", f"{branch_name}:{file_path}")
 
-    def fetch(self, remote: Optional[str] = "origin", refspec: Optional[str] = None):
+    def fetch(self, remote: str | None = "origin", refspec: str | None = None):
         if refspec is not None:
             self._stream_exec("fetch", remote, refspec)
         else:
             self._stream_exec("fetch", remote)
 
-    def remote(self) -> List[GitRemote]:
+    def remote(self) -> list[GitRemote]:
         remotes = []
         for line in self._iter_output("remote", "-v"):
             name, uri_ref = line.split("\t")

--- a/src/gh_worktree/hooks.py
+++ b/src/gh_worktree/hooks.py
@@ -3,12 +3,11 @@ import os
 import stat
 from contextlib import contextmanager
 from enum import Enum
+from pathlib import Path
 
 from gh_worktree.context import Context
 from gh_worktree.operator import ConfigOperator
-from gh_worktree.utils import COLOR_RESET
-from gh_worktree.utils import COLOR_YELLOW
-from gh_worktree.utils import stream_exec
+from gh_worktree.utils import COLOR_RESET, COLOR_YELLOW, stream_exec
 
 
 class Hook(Enum):
@@ -72,9 +71,7 @@ class Hooks(ConfigOperator):
                 print(f"Hook {hook_file_str} is not executable. Skipping.")
                 continue
 
-            if not self._check_allowed(
-                hook_file_str, bypass_allowlist=bypass_allowlist
-            ):
+            if not self._check_allowed(hook_file, bypass_allowlist=bypass_allowlist):
                 print(f"Hook {hook_file_str} is not allowed to run. Skipping.")
                 continue
 
@@ -82,38 +79,37 @@ class Hooks(ConfigOperator):
             command_args = [hook_file_str, *[str(arg) for arg in args]]
             return_status = stream_exec(command_args, cwd=self.context.cwd)
             if return_status != 0:
-                raise RuntimeError(
-                    f"Hook {hook.name} failed with exit code {return_status}"
-                )
+                raise RuntimeError(f"Hook {hook.name} failed with exit code {return_status}")
         return fired
 
-    def _check_allowed(self, hook_file: str, bypass_allowlist: bool = False) -> bool:
+    def _check_allowed(self, hook_file: Path, bypass_allowlist: bool = False) -> bool:
         """
         Check if a hook is allowed to run.
         :param hook_file: The path to the hook file
         :param bypass_allowlist: Whether to bypass the allowlist check
         :return: Whether the hook is allowed to run
         """
-        with open(hook_file, "rb") as f:
+        with hook_file.open("rb") as f:
             content = f.read()
         checksum = hashlib.sha256(content).hexdigest()
 
         global_config = self.context.get_global_config()
         allowed_hooks = global_config.allowed_hooks
+        hook_file_str = str(hook_file)
 
-        if hook_file in allowed_hooks and allowed_hooks[hook_file] == checksum:
+        if hook_file_str in allowed_hooks and allowed_hooks[hook_file_str] == checksum:
             return True
 
-        print(f"New/modified hook found: {hook_file}")
+        print(f"New/modified hook found: {hook_file_str}")
         if bypass_allowlist:
             print(
-                f"{COLOR_YELLOW}WARNING! Bypassing allowlist check for {hook_file}{COLOR_RESET}"
+                f"{COLOR_YELLOW}WARNING! Bypassing allowlist check for {hook_file_str}{COLOR_RESET}"
             )
             return True
 
         response = input("Do you want to allow this hook to run? (y/N): ")
         if response.lower() == "y":
-            global_config.allow_hook(hook_file, checksum)
+            global_config.allow_hook(hook_file_str, checksum)
             self.context.set_config(global_config)
             return True
 

--- a/src/gh_worktree/operator.py
+++ b/src/gh_worktree/operator.py
@@ -1,10 +1,10 @@
+from collections.abc import Iterator
 from pathlib import Path
-from typing import Iterator
 
 from gh_worktree.context import Context
 
 
-class ConfigOperator(object):
+class ConfigOperator:
     """
     Base class for utility classes that rely on the configuration directories.
     """

--- a/src/gh_worktree/runtime.py
+++ b/src/gh_worktree/runtime.py
@@ -1,14 +1,11 @@
-from typing import Optional
-
 from gh_worktree.context import Context
 from gh_worktree.gh import GithubCLI
-from gh_worktree.git import GitCLI
-from gh_worktree.git import GitRemote
+from gh_worktree.git import GitCLI, GitRemote
 from gh_worktree.hooks import Hooks
 from gh_worktree.templates import Templates
 
 
-class Runtime(object):
+class Runtime:
     __slots__ = ("context", "hooks", "git", "gh", "templates")
 
     def __init__(self):
@@ -18,12 +15,12 @@ class Runtime(object):
         self.gh = GithubCLI(self.context)
         self.templates = Templates(self.context)
 
-    def get_default_remote(self) -> Optional[GitRemote]:
+    def get_default_remote(self) -> GitRemote | None:
         return self.get_remote(owner_name=self.context.get_config().owner)
 
     def get_remote(
-        self, name: Optional[str] = None, owner_name: Optional[str] = None
-    ) -> Optional[GitRemote]:
+        self, name: str | None = None, owner_name: str | None = None
+    ) -> GitRemote | None:
         remote_ref = None
         if owner_name:
             config = self.context.get_config()
@@ -35,9 +32,7 @@ class Runtime(object):
         for remote in self.git.remote():
             if remote.type != "fetch":
                 continue
-            if (remote_ref and remote_ref in remote.uri) or (
-                name and name == remote.name
-            ):
+            if (remote_ref and remote_ref in remote.uri) or (name and name == remote.name):
                 return remote
 
         return None

--- a/src/gh_worktree/templates.py
+++ b/src/gh_worktree/templates.py
@@ -39,9 +39,7 @@ class Templates(ConfigOperator):
         self.replacement_map["REPO_NAME"] = config.name
         self.replacement_map["REPO_DIR"] = str(self.context.project_dir)
         self.replacement_map["WORKTREE_NAME"] = worktree_name
-        self.replacement_map["WORKTREE_NAME_NORMALIZED"] = normalize_worktree_name(
-            worktree_name
-        )
+        self.replacement_map["WORKTREE_NAME_NORMALIZED"] = normalize_worktree_name(worktree_name)
         self.replacement_map["WORKTREE_DIR"] = str(worktree_dir)
 
         for templates_dir in self.iter_config_dirs():

--- a/src/gh_worktree/utils.py
+++ b/src/gh_worktree/utils.py
@@ -3,9 +3,6 @@ import re
 import shlex
 import subprocess
 from pathlib import Path
-from typing import List
-from typing import Optional
-from typing import Union
 
 # Simple ANSI colors for the prefix
 COLOR_YELLOW = "\033[93m"
@@ -13,7 +10,7 @@ COLORS = ["\033[92m", "\033[94m", "\033[95m", "\033[96m", COLOR_YELLOW]
 COLOR_RESET = "\033[0m"
 
 
-def find_up(name: str, start_path: Union[str, Path]) -> Path:
+def find_up(name: str, start_path: str | Path) -> Path:
     """
     Looks upward for a directory that has file or directory with `name`
     :param name: The name of the file or directory to look for
@@ -33,7 +30,7 @@ def find_up(name: str, start_path: Union[str, Path]) -> Path:
     raise RuntimeError(f"Could not find {name} in {start_path} ancestors")
 
 
-def _log_prefix(command: List[str]) -> str:
+def _log_prefix(command: list[str]) -> str:
     """
     Returns a prefix string for visibility, via logging, into the command being executed
     :param command: The command list to be executed
@@ -47,9 +44,7 @@ def _log_prefix(command: List[str]) -> str:
     return shlex.join(command_prefix)
 
 
-def stream_exec(
-    command: List[str], wait_time: int = 60, cwd: Optional[Union[str, Path]] = None
-) -> int:
+def stream_exec(command: list[str], wait_time: int = 60, cwd: str | Path | None = None) -> int:
     """
     Executes a command in a subprocess and streams its output to stdout.
     :param command: The command to execute as a list of strings
@@ -95,9 +90,7 @@ def normalize_worktree_name(name: str) -> str:
     return result
 
 
-def iter_output(
-    command: List[str], wait_time: int = 60, cwd: Optional[Union[str, Path]] = None
-):
+def iter_output(command: list[str], wait_time: int = 60, cwd: str | Path | None = None):
     """
     Executes a command in a subprocess and iterates its output after completion
     :param command: The command to execute as a list of strings

--- a/tests/commands/test_checkout.py
+++ b/tests/commands/test_checkout.py
@@ -2,8 +2,7 @@ from contextlib import contextmanager
 from pathlib import Path
 from types import SimpleNamespace
 from unittest import TestCase
-from unittest.mock import ANY
-from unittest.mock import Mock
+from unittest.mock import ANY, Mock
 
 from gh_worktree.commands.checkout import CheckoutCommand
 from gh_worktree.git import GitRemote

--- a/tests/commands/test_create.py
+++ b/tests/commands/test_create.py
@@ -119,9 +119,7 @@ class CreateCommandTestCase(TestCase):
         self.assertTrue(self.context.assert_called)
         self.runtime.get_remote.assert_not_called()
         self.git.fetch.assert_called_once_with("upstream")
-        self.git.add_worktree.assert_called_once_with(
-            "feature", "upstream/some/nested/branch"
-        )
+        self.git.add_worktree.assert_called_once_with("feature", "upstream/some/nested/branch")
         self.templates.copy.assert_called_once_with("feature")
         self.hooks.fire.assert_any_call(
             Hook.pre_create,

--- a/tests/commands/test_init.py
+++ b/tests/commands/test_init.py
@@ -3,12 +3,9 @@ import tempfile
 from contextlib import contextmanager
 from types import SimpleNamespace
 from unittest import TestCase
-from unittest.mock import MagicMock
-from unittest.mock import Mock
+from unittest.mock import MagicMock, Mock
 
-from gh_worktree.commands.init import InitCommand
-from gh_worktree.commands.init import normalize
-from gh_worktree.commands.init import RepositoryTarget
+from gh_worktree.commands.init import InitCommand, RepositoryTarget, normalize
 from gh_worktree.hooks import Hook
 
 
@@ -59,9 +56,7 @@ class RepositoryTargetTestCase(TestCase):
 
     def test_validate__invalid_path(self):
         target = RepositoryTarget("https://github.com/octo/repo/pull/123.git")
-        with self.assertRaises(
-            ValueError, msg="Invalid repository path: octo/repo/pull/123"
-        ):
+        with self.assertRaises(ValueError, msg="Invalid repository path: octo/repo/pull/123"):
             target.validate()
 
     def test_path__url(self):
@@ -136,9 +131,7 @@ class InitCommandTestCase(TestCase):
         command = InitCommand(self.runtime)
         command("octo/repo", str(self.project_dir))
 
-        self.git.clone.assert_called_once_with(
-            "https://github.com/octo/repo.git", ".bare"
-        )
+        self.git.clone.assert_called_once_with("https://github.com/octo/repo.git", ".bare")
         self.git.config.assert_called_once_with(
             "remote.origin.fetch", "+refs/heads/*:refs/remotes/origin/*"
         )
@@ -191,9 +184,7 @@ class InitCommandTestCase(TestCase):
         command = InitCommand(self.runtime)
         command("octo/repo", str(self.project_dir))
 
-        self.runtime.templates.add.assert_called_once_with(
-            ".gh/worktree/templates/example.txt"
-        )
+        self.runtime.templates.add.assert_called_once_with(".gh/worktree/templates/example.txt")
         mock_f.write.assert_called_once_with("hello\n")
 
     def test_add_templates__skips_existing(self):
@@ -210,9 +201,7 @@ class InitCommandTestCase(TestCase):
         command = InitCommand(self.runtime)
         command._add_templates(config)
 
-        self.runtime.templates.add.assert_called_once_with(
-            ".gh/worktree/templates/example.txt"
-        )
+        self.runtime.templates.add.assert_called_once_with(".gh/worktree/templates/example.txt")
         self.git.cat_file.assert_not_called()
 
     def test_call__yes_true_sets_bypass_allowlist_true(self):

--- a/tests/commands/test_install.py
+++ b/tests/commands/test_install.py
@@ -39,13 +39,7 @@ class InstallCommandTestCase(TestCase):
         self.command(gh_ext=True)
 
         expected_target = (
-            Path.home()
-            / ".local"
-            / "share"
-            / "gh"
-            / "extensions"
-            / "gh-worktree"
-            / "gh-worktree"
+            Path.home() / ".local" / "share" / "gh" / "extensions" / "gh-worktree" / "gh-worktree"
         )
         mock_copy.assert_called_once_with(Path("/usr/bin/gh-worktree"), expected_target)
 
@@ -70,13 +64,7 @@ class InstallCommandTestCase(TestCase):
         self.command(alias="wktr", gh_ext=True)
 
         expected_target = (
-            Path.home()
-            / ".local"
-            / "share"
-            / "gh"
-            / "extensions"
-            / "gh-wktr"
-            / "gh-wktr"
+            Path.home() / ".local" / "share" / "gh" / "extensions" / "gh-wktr" / "gh-wktr"
         )
         mock_copy.assert_called_once_with(Path("/usr/bin/gh-worktree"), expected_target)
 
@@ -101,13 +89,7 @@ class InstallCommandTestCase(TestCase):
         self.command(alias="worktree", gh_ext=True)
 
         expected_target = (
-            Path.home()
-            / ".local"
-            / "share"
-            / "gh"
-            / "extensions"
-            / "gh-worktree"
-            / "gh-worktree"
+            Path.home() / ".local" / "share" / "gh" / "extensions" / "gh-worktree" / "gh-worktree"
         )
         mock_copy.assert_called_once_with(Path("/usr/bin/gh-worktree"), expected_target)
 
@@ -172,7 +154,7 @@ class InstallCommandTestCase(TestCase):
         )
 
     @patch("sys.argv", ["/home/user/gh-worktree/src/gh_worktree/main.py"])
-    @patch("os.symlink")
+    @patch("pathlib.Path.symlink_to", autospec=True)
     @patch("pathlib.Path.mkdir")
     @patch("pathlib.Path.exists", return_value=False)
     @patch("pathlib.Path.is_symlink", return_value=False)
@@ -184,18 +166,12 @@ class InstallCommandTestCase(TestCase):
 
         expected_source = Path("/home/user/gh-worktree/src/gh_worktree/main.py")
         expected_target = (
-            Path.home()
-            / ".local"
-            / "share"
-            / "gh"
-            / "extensions"
-            / "gh-worktree"
-            / "gh-worktree"
+            Path.home() / ".local" / "share" / "gh" / "extensions" / "gh-worktree" / "gh-worktree"
         )
-        mock_symlink.assert_called_once_with(expected_source, expected_target)
+        mock_symlink.assert_called_once_with(expected_target, expected_source)
 
     @patch("sys.argv", ["/home/user/gh-worktree/.venv/bin/gh-worktree"])
-    @patch("os.symlink")
+    @patch("pathlib.Path.symlink_to", autospec=True)
     @patch("pathlib.Path.mkdir")
     @patch("pathlib.Path.exists", return_value=False)
     @patch("pathlib.Path.is_symlink", return_value=False)
@@ -207,15 +183,9 @@ class InstallCommandTestCase(TestCase):
 
         expected_source = Path("/home/user/gh-worktree/.venv/bin/gh-worktree")
         expected_target = (
-            Path.home()
-            / ".local"
-            / "share"
-            / "gh"
-            / "extensions"
-            / "gh-worktree"
-            / "gh-worktree"
+            Path.home() / ".local" / "share" / "gh" / "extensions" / "gh-worktree" / "gh-worktree"
         )
-        mock_symlink.assert_called_once_with(expected_source, expected_target)
+        mock_symlink.assert_called_once_with(expected_target, expected_source)
 
     @patch("sys.argv", ["/usr/bin/gh-worktree"])
     @patch("shutil.copy")
@@ -239,13 +209,7 @@ class InstallCommandTestCase(TestCase):
 
         expected_source = Path("/usr/bin/gh-worktree")
         expected_target = (
-            Path.home()
-            / ".local"
-            / "share"
-            / "gh"
-            / "extensions"
-            / "gh-worktree"
-            / "gh-worktree"
+            Path.home() / ".local" / "share" / "gh" / "extensions" / "gh-worktree" / "gh-worktree"
         )
         mock_copy.assert_called_once_with(expected_source, expected_target)
         mock_chmod.assert_called_once()
@@ -272,13 +236,7 @@ class InstallCommandTestCase(TestCase):
 
         expected_source = Path("/usr/bin/gh-worktree.pex")
         expected_target = (
-            Path.home()
-            / ".local"
-            / "share"
-            / "gh"
-            / "extensions"
-            / "gh-worktree"
-            / "gh-worktree"
+            Path.home() / ".local" / "share" / "gh" / "extensions" / "gh-worktree" / "gh-worktree"
         )
         mock_copy.assert_called_once_with(expected_source, expected_target)
 
@@ -305,13 +263,7 @@ class InstallCommandTestCase(TestCase):
         self.command()
 
         expected_target = (
-            Path.home()
-            / ".local"
-            / "share"
-            / "gh"
-            / "extensions"
-            / "gh-worktree"
-            / "gh-worktree"
+            Path.home() / ".local" / "share" / "gh" / "extensions" / "gh-worktree" / "gh-worktree"
         )
         mock_copy.assert_called_once_with(Path("/usr/bin/gh-worktree"), expected_target)
 
@@ -361,13 +313,7 @@ class InstallCommandTestCase(TestCase):
 
         self.assertEqual(cm.exception.code, 1)
         expected_target = (
-            Path.home()
-            / ".local"
-            / "share"
-            / "gh"
-            / "extensions"
-            / "gh-worktree"
-            / "gh-worktree"
+            Path.home() / ".local" / "share" / "gh" / "extensions" / "gh-worktree" / "gh-worktree"
         )
         mock_print.assert_called_with(
             f"Path already exists, use --force to overwrite: {expected_target}"
@@ -385,13 +331,7 @@ class InstallCommandTestCase(TestCase):
 
         self.assertEqual(cm.exception.code, 1)
         expected_target = (
-            Path.home()
-            / ".local"
-            / "share"
-            / "gh"
-            / "extensions"
-            / "gh-worktree"
-            / "gh-worktree"
+            Path.home() / ".local" / "share" / "gh" / "extensions" / "gh-worktree" / "gh-worktree"
         )
         mock_print.assert_called_with(
             f"Path already exists, use --force to overwrite: {expected_target}"
@@ -420,13 +360,7 @@ class InstallCommandTestCase(TestCase):
         self.command(gh_ext=True, force=True)
 
         expected_target = (
-            Path.home()
-            / ".local"
-            / "share"
-            / "gh"
-            / "extensions"
-            / "gh-worktree"
-            / "gh-worktree"
+            Path.home() / ".local" / "share" / "gh" / "extensions" / "gh-worktree" / "gh-worktree"
         )
         mock_unlink.assert_called_once_with(True)
         mock_copy.assert_called_once_with(Path("/usr/bin/gh-worktree"), expected_target)

--- a/tests/commands/test_remove.py
+++ b/tests/commands/test_remove.py
@@ -53,12 +53,8 @@ class RemoveCommandTestCase(TestCase):
         command("feature", force=True)
 
         git.remove_worktree.assert_called_once_with("feature", force=True)
-        hooks.fire.assert_any_call(
-            Hook.pre_remove, "feature", "feature", bypass_allowlist=False
-        )
-        hooks.fire.assert_any_call(
-            Hook.post_remove, "feature", "feature", bypass_allowlist=False
-        )
+        hooks.fire.assert_any_call(Hook.pre_remove, "feature", "feature", bypass_allowlist=False)
+        hooks.fire.assert_any_call(Hook.post_remove, "feature", "feature", bypass_allowlist=False)
 
     def test_call__yes_true_sets_bypass_allowlist_true(self):
         project_dir = self.tmp_path / "project"
@@ -73,9 +69,5 @@ class RemoveCommandTestCase(TestCase):
         command = RemoveCommand(runtime)
         command("feature", yes=True)
 
-        hooks.fire.assert_any_call(
-            Hook.pre_remove, "feature", "feature", bypass_allowlist=True
-        )
-        hooks.fire.assert_any_call(
-            Hook.post_remove, "feature", "feature", bypass_allowlist=True
-        )
+        hooks.fire.assert_any_call(Hook.pre_remove, "feature", "feature", bypass_allowlist=True)
+        hooks.fire.assert_any_call(Hook.post_remove, "feature", "feature", bypass_allowlist=True)

--- a/tests/test_gh.py
+++ b/tests/test_gh.py
@@ -2,8 +2,7 @@ import json
 import subprocess
 from pathlib import Path
 from types import SimpleNamespace
-from unittest import mock
-from unittest import TestCase
+from unittest import TestCase, mock
 
 from gh_worktree.gh import GithubCLI
 

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -1,10 +1,8 @@
 from pathlib import Path
 from types import SimpleNamespace
-from unittest import mock
-from unittest import TestCase
+from unittest import TestCase, mock
 
-from gh_worktree.git import GitCLI
-from gh_worktree.git import GitRemote
+from gh_worktree.git import GitCLI, GitRemote
 
 
 class GitCLITestCase(TestCase):
@@ -23,24 +21,18 @@ class GitCLITestCase(TestCase):
 
     def test_stream_exec(self):
         self.cli._stream_exec("foo", "bar")
-        self.mock_stream_exec.assert_called_once_with(
-            ["git", "foo", "bar"], cwd=Path("/test/tmp")
-        )
+        self.mock_stream_exec.assert_called_once_with(["git", "foo", "bar"], cwd=Path("/test/tmp"))
 
     def test_stream_exec__fail(self):
         self.mock_stream_exec.return_value = 1
         with self.assertRaises(RuntimeError):
             self.cli._stream_exec("foo", "bar")
-        self.mock_stream_exec.assert_called_once_with(
-            ["git", "foo", "bar"], cwd=Path("/test/tmp")
-        )
+        self.mock_stream_exec.assert_called_once_with(["git", "foo", "bar"], cwd=Path("/test/tmp"))
 
     def test_iter_output(self):
         self.mock_iter_output.return_value = ["line1", "line2"]
         lines = list(self.cli._iter_output("foo", "bar"))
-        self.mock_iter_output.assert_called_once_with(
-            ["git", "foo", "bar"], cwd=Path("/test/tmp")
-        )
+        self.mock_iter_output.assert_called_once_with(["git", "foo", "bar"], cwd=Path("/test/tmp"))
         self.assertEqual(lines, ["line1", "line2"])
 
     def test_clone(self):
@@ -74,9 +66,7 @@ class GitCLITestCase(TestCase):
 
     def test_fetch(self):
         self.cli.fetch()
-        self.mock_stream_exec.assert_called_with(
-            ["git", "fetch", "origin"], cwd=Path("/test/tmp")
-        )
+        self.mock_stream_exec.assert_called_with(["git", "fetch", "origin"], cwd=Path("/test/tmp"))
 
         self.cli.fetch(remote="upstream", refspec="master")
         self.mock_stream_exec.assert_called_with(

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -3,13 +3,10 @@ import os
 import stat
 import tempfile
 from pathlib import Path
-from unittest import mock
-from unittest import TestCase
+from unittest import TestCase, mock
 
 from gh_worktree.context import Context
-from gh_worktree.hooks import Hook
-from gh_worktree.hooks import HookExists
-from gh_worktree.hooks import Hooks
+from gh_worktree.hooks import Hook, HookExists, Hooks
 
 
 class HooksTestCase(TestCase):
@@ -39,7 +36,7 @@ class HooksTestCase(TestCase):
         global_config.allow_hook(str(hook_file), checksum)
         self.context.set_config(global_config)
 
-        self.assertTrue(self.hooks._check_allowed(str(hook_file)))
+        self.assertTrue(self.hooks._check_allowed(hook_file))
 
         mock_input.assert_not_called()
         global_config = self.context.get_global_config()
@@ -53,7 +50,7 @@ class HooksTestCase(TestCase):
 
         mock_input.return_value = "y"
 
-        self.assertTrue(self.hooks._check_allowed(str(hook_file)))
+        self.assertTrue(self.hooks._check_allowed(hook_file))
 
         mock_input.assert_called_once()
         global_config = self.context.get_global_config()
@@ -71,9 +68,7 @@ class HooksTestCase(TestCase):
         mock_stream_exec.return_value = 0
 
         self.assertTrue(self.hooks.fire(Hook.pre_init, "arg1"))
-        mock_stream_exec.assert_called_once_with(
-            [str(hook_file), "arg1"], cwd=self.tmp_path
-        )
+        mock_stream_exec.assert_called_once_with([str(hook_file), "arg1"], cwd=self.tmp_path)
 
     @mock.patch("gh_worktree.hooks.Hooks._check_allowed")
     @mock.patch("gh_worktree.hooks.stream_exec")

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -20,9 +20,7 @@ class RuntimeTestCase(TestCase):
         self.runtime.git = SimpleNamespace(remote=lambda: self.remotes)
 
     def test_get_remote__no_args_raises(self):
-        with self.assertRaises(
-            ValueError, msg="Must provide either owner_name or name"
-        ):
+        with self.assertRaises(ValueError, msg="Must provide either owner_name or name"):
             self.runtime.get_remote()
 
     def test_get_remote__owner_name(self):

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -5,14 +5,11 @@ from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import patch
 
-from gh_worktree.templates import TemplateExists
-from gh_worktree.templates import Templates
+from gh_worktree.templates import TemplateExists, Templates
 
 
 class StubContext:
-    def __init__(
-        self, project_dir, config, global_config, config_dir, global_config_dir
-    ):
+    def __init__(self, project_dir, config, global_config, config_dir, global_config_dir):
         self.project_dir = project_dir
         self._config = config
         self._global_config = global_config
@@ -47,9 +44,7 @@ class TemplatesTestCase(unittest.TestCase):
             "REPO: $REPO_NAME\nWORKTREE: $WORKTREE_NAME\n"
         )
 
-        (self.project_templates_dir / "env.txt").write_text(
-            "PATH: $WORKTREE_DIR\nUSER: $USER\n"
-        )
+        (self.project_templates_dir / "env.txt").write_text("PATH: $WORKTREE_DIR\nUSER: $USER\n")
 
         # Create a subdirectory with a template
         subdir = self.project_templates_dir / "subdir"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,8 +2,7 @@ import tempfile
 from pathlib import Path
 from unittest import TestCase
 
-from gh_worktree.utils import find_up
-from gh_worktree.utils import normalize_worktree_name
+from gh_worktree.utils import find_up, normalize_worktree_name
 
 
 class FindUpTestCase(TestCase):
@@ -50,24 +49,16 @@ class NormalizeWorktreeNameTestCase(TestCase):
         self.assertEqual(normalize_worktree_name("feature"), "feature")
 
     def test_slash_replaced_with_dash(self):
-        self.assertEqual(
-            normalize_worktree_name("feat/some-feature"), "feat-some-feature"
-        )
+        self.assertEqual(normalize_worktree_name("feat/some-feature"), "feat-some-feature")
 
     def test_multiple_slashes_collapsed(self):
-        self.assertEqual(
-            normalize_worktree_name("feat/nested/branch"), "feat-nested-branch"
-        )
+        self.assertEqual(normalize_worktree_name("feat/nested/branch"), "feat-nested-branch")
 
     def test_dashes_preserved(self):
-        self.assertEqual(
-            normalize_worktree_name("my-feature-branch"), "my-feature-branch"
-        )
+        self.assertEqual(normalize_worktree_name("my-feature-branch"), "my-feature-branch")
 
     def test_underscores_replaced(self):
-        self.assertEqual(
-            normalize_worktree_name("my_feature_branch"), "my-feature-branch"
-        )
+        self.assertEqual(normalize_worktree_name("my_feature_branch"), "my-feature-branch")
 
     def test_mixed_slashes_and_dashes(self):
         self.assertEqual(normalize_worktree_name("feat/my-feature"), "feat-my-feature")

--- a/uv.lock
+++ b/uv.lock
@@ -46,7 +46,7 @@ wheels = [
 
 [[package]]
 name = "gh-worktree"
-version = "0.3.1"
+version = "0.3.2"
 source = { editable = "." }
 dependencies = [
     { name = "fire" },

--- a/uv.lock
+++ b/uv.lock
@@ -55,6 +55,7 @@ dependencies = [
 [package.dev-dependencies]
 dev = [
     { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
+    { name = "pex" },
     { name = "prek" },
     { name = "pyinstaller" },
     { name = "pytest" },
@@ -67,6 +68,7 @@ requires-dist = [{ name = "fire", specifier = ">=0.7.1" }]
 [package.metadata.requires-dev]
 dev = [
     { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
+    { name = "pex", specifier = ">=2.88.1" },
     { name = "prek" },
     { name = "pyinstaller" },
     { name = "pytest", specifier = ">=8.0.0" },
@@ -110,6 +112,16 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/03/4f/2750f7f6f025a1507cd3b7218691671eecfd0bbebebe8b39aa0fe1d360b8/pefile-2024.8.26.tar.gz", hash = "sha256:3ff6c5d8b43e8c37bb6e6dd5085658d658a7a0bdcd20b6a07b1fcfc1c4e9d632", size = 76008, upload-time = "2024-08-26T20:58:38.155Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/16/12b82f791c7f50ddec566873d5bdd245baa1491bac11d15ffb98aecc8f8b/pefile-2024.8.26-py3-none-any.whl", hash = "sha256:76f8b485dcd3b1bb8166f1128d395fa3d87af26360c2358fb75b80019b957c6f", size = 74766, upload-time = "2024-08-26T21:01:02.632Z" },
+]
+
+[[package]]
+name = "pex"
+version = "2.92.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5e/03/df286ec0084a29afb17af9e6dbe5f3467ea287c8529abb60e2eff80b40f5/pex-2.92.3.tar.gz", hash = "sha256:68da713e979e4ab18f90e0dd193a0efbff014101b062626fde6e368b16225f3e", size = 5279282, upload-time = "2026-04-15T14:57:49.875Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4e/6b/648f7e06cedeeae57dd575f0987c7926cf06ccbe188239edbd8fe7271d26/pex-2.92.3-py2.py35.py36.py37.py38.py39.py310.py311-none-any.whl", hash = "sha256:5d5b8728d2d26d87f8fa006c4b3a02c64c1c2e6392d37582cbe5ad1e2b93c850", size = 3970652, upload-time = "2026-04-15T14:57:45.38Z" },
+    { url = "https://files.pythonhosted.org/packages/08/48/ad484a266a227935e2b5206e1d95f9ffb58959537a21d57096024b23d97a/pex-2.92.3-py3.py312-none-any.whl", hash = "sha256:8578e7b93fdf1e4cf0e3e2039392a68eed243d0a96a8303bedfef7a47a62c7bc", size = 1770270, upload-time = "2026-04-15T14:57:47.806Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -2,6 +2,10 @@ version = 1
 revision = 3
 requires-python = ">=3.10"
 
+[options]
+exclude-newer = "2026-04-11T15:53:58.518447459Z"
+exclude-newer-span = "P7D"
+
 [[package]]
 name = "altgraph"
 version = "0.17.5"
@@ -72,7 +76,7 @@ dev = [
     { name = "prek" },
     { name = "pyinstaller" },
     { name = "pytest", specifier = ">=8.0.0" },
-    { name = "ruff", specifier = ">=0.15.11" },
+    { name = "ruff", specifier = ">=0.15.10" },
 ]
 
 [[package]]
@@ -116,12 +120,12 @@ wheels = [
 
 [[package]]
 name = "pex"
-version = "2.92.3"
+version = "2.92.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/5e/03/df286ec0084a29afb17af9e6dbe5f3467ea287c8529abb60e2eff80b40f5/pex-2.92.3.tar.gz", hash = "sha256:68da713e979e4ab18f90e0dd193a0efbff014101b062626fde6e368b16225f3e", size = 5279282, upload-time = "2026-04-15T14:57:49.875Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/16/83/d6cc12a73a93c9eeb7b2e25b5fc3429175f5fb6b97ed402867834539ffbe/pex-2.92.1.tar.gz", hash = "sha256:760eaa58beb9d882531f41891b3a63dfa7da3a02d314094b45fdaa4ee2dcef6e", size = 5276931, upload-time = "2026-04-06T23:06:23.82Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4e/6b/648f7e06cedeeae57dd575f0987c7926cf06ccbe188239edbd8fe7271d26/pex-2.92.3-py2.py35.py36.py37.py38.py39.py310.py311-none-any.whl", hash = "sha256:5d5b8728d2d26d87f8fa006c4b3a02c64c1c2e6392d37582cbe5ad1e2b93c850", size = 3970652, upload-time = "2026-04-15T14:57:45.38Z" },
-    { url = "https://files.pythonhosted.org/packages/08/48/ad484a266a227935e2b5206e1d95f9ffb58959537a21d57096024b23d97a/pex-2.92.3-py3.py312-none-any.whl", hash = "sha256:8578e7b93fdf1e4cf0e3e2039392a68eed243d0a96a8303bedfef7a47a62c7bc", size = 1770270, upload-time = "2026-04-15T14:57:47.806Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/49/77a16c87b24d3a05a3d98009fa5fc8447cfbfab7c1a85b5b5c7e32befb06/pex-2.92.1-py2.py35.py36.py37.py38.py39.py310.py311-none-any.whl", hash = "sha256:62f28a39737ebd700320c03a3d833c0b91803f1275f6d6d13fa4728c6076a2a1", size = 3970101, upload-time = "2026-04-06T23:06:20.1Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/c1/5e5d23dd33cd63667443eff6246998394ae9c3f4cb39cf1b6d0c1bb95763/pex-2.92.1-py3.py312-none-any.whl", hash = "sha256:9ad8a8f9b90083b177fd0933b187af0cf3d27f7163fe17288b310089ba43848a", size = 1769723, upload-time = "2026-04-06T23:06:22.029Z" },
 ]
 
 [[package]]
@@ -135,26 +139,26 @@ wheels = [
 
 [[package]]
 name = "prek"
-version = "0.3.9"
+version = "0.3.8"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/15/ff/5b7a2a9c4fa3dd2ffc8b13a9ec22aa550deda5b39ab273f8e02863b12642/prek-0.3.9.tar.gz", hash = "sha256:f82b92d81f42f1f90a47f5fbbf492373e25ef1f790080215b2722dd6da66510e", size = 423801, upload-time = "2026-04-13T12:30:38.191Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/62/ee/03e8180e3fda9de25b6480bd15cc2bde40d573868d50648b0e527b35562f/prek-0.3.8.tar.gz", hash = "sha256:434a214256516f187a3ab15f869d950243be66b94ad47987ee4281b69643a2d9", size = 400224, upload-time = "2026-03-23T08:23:35.981Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3c/08/c11a6b7834b461223763b6b1552f32c9199393685d52d555de621e900ee7/prek-0.3.9-py3-none-linux_armv6l.whl", hash = "sha256:3ed793d51bfaa27bddb64d525d7acb77a7c8644f549412d82252e3eb0b88aad8", size = 5337784, upload-time = "2026-04-13T12:30:46.044Z" },
-    { url = "https://files.pythonhosted.org/packages/15/d9/974b02832a645c6411069c713e3191ce807f9962006da108e4727efd2fa1/prek-0.3.9-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:399c58400c0bd0b82a93a3c09dc1bfd88d8d0cfb242d414d2ed247187b06ead1", size = 5713864, upload-time = "2026-04-13T12:30:27.007Z" },
-    { url = "https://files.pythonhosted.org/packages/40/e1/4ed14bef15eb30039a75177b0807ac007095a5a110284706ccf900a8d512/prek-0.3.9-py3-none-macosx_11_0_arm64.whl", hash = "sha256:e2ea1ffb124e92f081b8e2ca5b5a623a733efb3be0c5b1f4b7ffe2ee17d1f20c", size = 5290437, upload-time = "2026-04-13T12:30:30.658Z" },
-    { url = "https://files.pythonhosted.org/packages/67/80/d5c3015e9da161dede566bfeef41f098f92470613157daa4f7377ab08d58/prek-0.3.9-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.musllinux_1_1_aarch64.whl", hash = "sha256:aaf639f95b7301639298311d8d44aad0d0b4864e9736083ad3c71ce9765d37ab", size = 5536208, upload-time = "2026-04-13T12:30:47.964Z" },
-    { url = "https://files.pythonhosted.org/packages/c8/54/8cdc5eb1018437d7828740defd322e7a96459c02fc8961160c4120325313/prek-0.3.9-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:ff104863b187fa443ea8451ca55d51e2c6e94f99f00d88784b5c3c4c623f1ebe", size = 5251785, upload-time = "2026-04-13T12:30:39.78Z" },
-    { url = "https://files.pythonhosted.org/packages/bd/e2/a5fc35a0fd3167224a000ca1b6235ecbdea0ac77e24af5979a75b0e6b5a4/prek-0.3.9-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:039ecaf87c63a3e67cca645ebd5bc5eb6aafa6c9d929e9a27b2921e7849d7ef9", size = 5668548, upload-time = "2026-04-13T12:30:24.914Z" },
-    { url = "https://files.pythonhosted.org/packages/09/e8/a189ee79f401c259f66f8af587f899d4d5bfb04e0ca371bfd01e49871007/prek-0.3.9-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:3bde2a3d045705095983c7f78ba04f72a7565fe1c2b4e85f5628502a254754ff", size = 6660927, upload-time = "2026-04-13T12:30:44.495Z" },
-    { url = "https://files.pythonhosted.org/packages/a4/5a/54117316e98ff62a14911ad1488a3a0945530242a2ce3e92f7a40b6ccc02/prek-0.3.9-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:28a0960a21543563e2c8e19aaad176cc8423a87aac3c914d0f313030d7a9244a", size = 5932244, upload-time = "2026-04-13T12:30:49.532Z" },
-    { url = "https://files.pythonhosted.org/packages/a7/f9/e88d4361f59be7adeeb3a8a3819d69d286d86fe6f7606840af6734362675/prek-0.3.9-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:0dfb5d5171d7523271909246ee306b4dc3d5b63752e7dd7c7e8a8908fc9490d1", size = 5542139, upload-time = "2026-04-13T12:30:41.266Z" },
-    { url = "https://files.pythonhosted.org/packages/11/1f/204837115087bb8d063bda754a7fe975428c5d5b6548c30dd749f8ab85d4/prek-0.3.9-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:82b791bd36c1430c84d3ae7220a85152babc7eaf00f70adcb961bd594e756ba3", size = 5392519, upload-time = "2026-04-13T12:30:32.603Z" },
-    { url = "https://files.pythonhosted.org/packages/bd/00/de57b5795e670b6d38e7eda6d9ac6fd6d757ca22f725e5054b042104cd53/prek-0.3.9-py3-none-musllinux_1_1_armv7l.whl", hash = "sha256:6eac6d2f736b041118f053a1487abed468a70dd85a8688eaf87bb42d3dcecf20", size = 5222780, upload-time = "2026-04-13T12:30:36.576Z" },
-    { url = "https://files.pythonhosted.org/packages/f5/14/0bc055c305d92980b151f2ec00c14d28fe94c6d51180ca07fded28771cbf/prek-0.3.9-py3-none-musllinux_1_1_i686.whl", hash = "sha256:5517e46e761367a3759b3168eabc120840ffbca9dfbc53187167298a98f87dc4", size = 5524310, upload-time = "2026-04-13T12:30:34.469Z" },
-    { url = "https://files.pythonhosted.org/packages/b9/d1/eebc2b69be0de36cd84adbe0a0710f4deb468a90e30525be027d6db02d54/prek-0.3.9-py3-none-musllinux_1_1_x86_64.whl", hash = "sha256:92024778cf78683ca32687bb249ab6a7d5c33887b5ee1d1a9f6d0c14228f4cf3", size = 6043751, upload-time = "2026-04-13T12:30:29.101Z" },
-    { url = "https://files.pythonhosted.org/packages/46/cb/be98c04e702cbc0b0328cd745ff4634ace69ad5a84461bde36f88a7be873/prek-0.3.9-py3-none-win32.whl", hash = "sha256:7f89c55e5f480f5d073769e319924ad69d4bf9f98c5cb46a83082e26e634c958", size = 5045940, upload-time = "2026-04-13T12:30:42.882Z" },
-    { url = "https://files.pythonhosted.org/packages/a6/b6/b51771d69f6282e34edeb73f23d956da34f2cabbb5ba16ba175cc0a056f9/prek-0.3.9-py3-none-win_amd64.whl", hash = "sha256:7722f3372eaa83b147e70a43cb7b9fe2128c13d0c78d8a1cdbf2a8ec2ee071eb", size = 5435204, upload-time = "2026-04-13T12:30:51.482Z" },
-    { url = "https://files.pythonhosted.org/packages/30/8a/f8a87c15b095460eccd67c8d89a086b7a37aac8d363f89544b8ce6ec653d/prek-0.3.9-py3-none-win_arm64.whl", hash = "sha256:0bced6278d6cc8a4b46048979e36bc9da034611dc8facd77ab123177b833a929", size = 5279552, upload-time = "2026-04-13T12:30:53.011Z" },
+    { url = "https://files.pythonhosted.org/packages/00/84/40d2ddf362d12c4cd4a25a8c89a862edf87cdfbf1422aa41aac8e315d409/prek-0.3.8-py3-none-linux_armv6l.whl", hash = "sha256:6fb646ada60658fa6dd7771b2e0fb097f005151be222f869dada3eb26d79ed33", size = 5226646, upload-time = "2026-03-23T08:23:18.306Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/52/7308a033fa43b7e8e188797bd2b3b017c0f0adda70fa7af575b1f43ea888/prek-0.3.8-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:f3d7fdadb15efc19c09953c7a33cf2061a70f367d1e1957358d3ad5cc49d0616", size = 5620104, upload-time = "2026-03-23T08:23:40.053Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/b1/f106ac000a91511a9cd80169868daf2f5b693480ef5232cec5517a38a512/prek-0.3.8-py3-none-macosx_11_0_arm64.whl", hash = "sha256:72728c3295e79ca443f8c1ec037d2a5b914ec73a358f69cf1bc1964511876bf8", size = 5199867, upload-time = "2026-03-23T08:23:38.066Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/e9/970713f4b019f69de9844e1bab37b8ddb67558e410916f4eb5869a696165/prek-0.3.8-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.musllinux_1_1_aarch64.whl", hash = "sha256:48efc28f2f53b5b8087efca9daaed91572d62df97d5f24a1c7a087fecb5017de", size = 5441801, upload-time = "2026-03-23T08:23:32.617Z" },
+    { url = "https://files.pythonhosted.org/packages/12/a4/7ef44032b181753e19452ec3b09abb3a32607cf6b0a0508f0604becaaf2b/prek-0.3.8-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f6ca9d63bacbc448a5c18e955c78d3ac5176c3a17c3baacdd949b1a623e08a36", size = 5155107, upload-time = "2026-03-23T08:23:31.021Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/77/4d9c8985dbba84149760785dfe07093ea1e29d710257dfb7c89615e2234c/prek-0.3.8-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1000f7029696b4fe712fb1fefd4c55b9c4de72b65509c8e50296370a06f9dc3f", size = 5566541, upload-time = "2026-03-23T08:23:45.694Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/1a/81e6769ac1f7f8346d09ce2ab0b47cf06466acd9ff72e87e5d1f0d98cd32/prek-0.3.8-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:6ff0bed0e2c1286522987d982168a86cbbd0d069d840506a46c9fda983515517", size = 6552991, upload-time = "2026-03-23T08:23:21.958Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/fa/ce2df0dd2dc75a9437a52463239d0782998943d7b04e191fb89b83016c34/prek-0.3.8-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4fb087ac0ffda3ac65bbbae9a38326a7fd27ee007bb4a94323ce1eb539d8bbec", size = 5832972, upload-time = "2026-03-23T08:23:20.258Z" },
+    { url = "https://files.pythonhosted.org/packages/18/6b/9d4269df9073216d296244595a21c253b6475dfc9076c0bd2906be7a436c/prek-0.3.8-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:2e1e5e206ff7b31bd079cce525daddc96cd6bc544d20dc128921ad92f7a4c85d", size = 5448371, upload-time = "2026-03-23T08:23:41.835Z" },
+    { url = "https://files.pythonhosted.org/packages/60/1d/1e4d8a78abefa5b9d086e5a9f1638a74b5e540eec8a648d9946707701f29/prek-0.3.8-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:dcea3fe23832a4481bccb7c45f55650cb233be7c805602e788bb7dba60f2d861", size = 5270546, upload-time = "2026-03-23T08:23:24.231Z" },
+    { url = "https://files.pythonhosted.org/packages/77/07/34f36551a6319ae36e272bea63a42f59d41d2d47ab0d5fb00eb7b4e88e87/prek-0.3.8-py3-none-musllinux_1_1_armv7l.whl", hash = "sha256:4d25e647e9682f6818ab5c31e7a4b842993c14782a6ffcd128d22b784e0d677f", size = 5124032, upload-time = "2026-03-23T08:23:26.368Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/01/6d544009bb655e709993411796af77339f439526db4f3b3509c583ad8eb9/prek-0.3.8-py3-none-musllinux_1_1_i686.whl", hash = "sha256:de528b82935e33074815acff3c7c86026754d1212136295bc88fe9c43b4231d5", size = 5432245, upload-time = "2026-03-23T08:23:47.877Z" },
+    { url = "https://files.pythonhosted.org/packages/54/96/1237ee269e9bfa283ffadbcba1f401f48a47aed2b2563eb1002740d6079d/prek-0.3.8-py3-none-musllinux_1_1_x86_64.whl", hash = "sha256:6d660f1c25a126e6d9f682fe61449441226514f412a4469f5d71f8f8cad56db2", size = 5950550, upload-time = "2026-03-23T08:23:43.8Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/6b/a574411459049bc691047c9912f375deda10c44a707b6ce98df2b658f0b3/prek-0.3.8-py3-none-win32.whl", hash = "sha256:b0c291c577615d9f8450421dff0b32bfd77a6b0d223ee4115a1f820cb636fdf1", size = 4949501, upload-time = "2026-03-23T08:23:16.338Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/b4/46b59fe49f635acd9f6530778ce577f9d8b49452835726a5311ffc902c67/prek-0.3.8-py3-none-win_amd64.whl", hash = "sha256:bc147fdbdd4ec33fc7a987b893ecb69b1413ac100d95c9889a70f3fd58c73d06", size = 5346551, upload-time = "2026-03-23T08:23:34.501Z" },
+    { url = "https://files.pythonhosted.org/packages/53/05/9cca1708bb8c65264124eb4b04251e0f65ce5bfc707080bb6b492d5a0df7/prek-0.3.8-py3-none-win_arm64.whl", hash = "sha256:a2614647aeafa817a5802ccb9561e92eedc20dcf840639a1b00826e2c2442515", size = 5190872, upload-time = "2026-03-23T08:23:29.463Z" },
 ]
 
 [[package]]
@@ -236,27 +240,27 @@ wheels = [
 
 [[package]]
 name = "ruff"
-version = "0.15.11"
+version = "0.15.10"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e4/8d/192f3d7103816158dfd5ea50d098ef2aec19194e6cbccd4b3485bdb2eb2d/ruff-0.15.11.tar.gz", hash = "sha256:f092b21708bf0e7437ce9ada249dfe688ff9a0954fc94abab05dcea7dcd29c33", size = 4637264, upload-time = "2026-04-16T18:46:26.58Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/d9/aa3f7d59a10ef6b14fe3431706f854dbf03c5976be614a9796d36326810c/ruff-0.15.10.tar.gz", hash = "sha256:d1f86e67ebfdef88e00faefa1552b5e510e1d35f3be7d423dc7e84e63788c94e", size = 4631728, upload-time = "2026-04-09T14:06:09.884Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/02/1e/6aca3427f751295ab011828e15e9bf452200ac74484f1db4be0197b8170b/ruff-0.15.11-py3-none-linux_armv6l.whl", hash = "sha256:e927cfff503135c558eb581a0c9792264aae9507904eb27809cdcff2f2c847b7", size = 10607943, upload-time = "2026-04-16T18:46:05.967Z" },
-    { url = "https://files.pythonhosted.org/packages/e7/26/1341c262e74f36d4e84f3d6f4df0ac68cd53331a66bfc5080daa17c84c0b/ruff-0.15.11-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:7a1b5b2938d8f890b76084d4fa843604d787a912541eae85fd7e233398bbb73e", size = 10988592, upload-time = "2026-04-16T18:46:00.742Z" },
-    { url = "https://files.pythonhosted.org/packages/03/71/850b1d6ffa9564fbb6740429bad53df1094082fe515c8c1e74b6d8d05f18/ruff-0.15.11-py3-none-macosx_11_0_arm64.whl", hash = "sha256:d4176f3d194afbdaee6e41b9ccb1a2c287dba8700047df474abfbe773825d1cb", size = 10338501, upload-time = "2026-04-16T18:46:03.723Z" },
-    { url = "https://files.pythonhosted.org/packages/f2/11/cc1284d3e298c45a817a6aadb6c3e1d70b45c9b36d8d9cce3387b495a03a/ruff-0.15.11-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3b17c886fb88203ced3afe7f14e8d5ae96e9d2f4ccc0ee66aa19f2c2675a27e4", size = 10670693, upload-time = "2026-04-16T18:46:41.941Z" },
-    { url = "https://files.pythonhosted.org/packages/ce/9e/f8288b034ab72b371513c13f9a41d9ba3effac54e24bfb467b007daee2ca/ruff-0.15.11-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:49fafa220220afe7758a487b048de4c8f9f767f37dfefad46b9dd06759d003eb", size = 10416177, upload-time = "2026-04-16T18:46:21.717Z" },
-    { url = "https://files.pythonhosted.org/packages/85/71/504d79abfd3d92532ba6bbe3d1c19fada03e494332a59e37c7c2dabae427/ruff-0.15.11-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f2ab8427e74a00d93b8bda1307b1e60970d40f304af38bccb218e056c220120d", size = 11221886, upload-time = "2026-04-16T18:46:15.086Z" },
-    { url = "https://files.pythonhosted.org/packages/43/5a/947e6ab7a5ad603d65b474be15a4cbc6d29832db5d762cd142e4e3a74164/ruff-0.15.11-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:195072c0c8e1fc8f940652073df082e37a5d9cb43b4ab1e4d0566ab8977a13b7", size = 12075183, upload-time = "2026-04-16T18:46:07.944Z" },
-    { url = "https://files.pythonhosted.org/packages/9f/a1/0b7bb6268775fdd3a0818aee8efd8f5b4e231d24dd4d528ced2534023182/ruff-0.15.11-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a3a0996d486af3920dec930a2e7daed4847dfc12649b537a9335585ada163e9e", size = 11516575, upload-time = "2026-04-16T18:46:31.687Z" },
-    { url = "https://files.pythonhosted.org/packages/30/c3/bb5168fc4d233cc06e95f482770d0f3c87945a0cd9f614b90ea8dc2f2833/ruff-0.15.11-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1bef2cb556d509259f1fe440bb9cd33c756222cf0a7afe90d15edf0866702431", size = 11306537, upload-time = "2026-04-16T18:46:36.988Z" },
-    { url = "https://files.pythonhosted.org/packages/e4/92/4cfae6441f3967317946f3b788136eecf093729b94d6561f963ed810c82e/ruff-0.15.11-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:030d921a836d7d4a12cf6e8d984a88b66094ccb0e0f17ddd55067c331191bf19", size = 11296813, upload-time = "2026-04-16T18:46:24.182Z" },
-    { url = "https://files.pythonhosted.org/packages/43/26/972784c5dde8313acde8ac71ba8ac65475b85db4a2352a76c9934361f9bc/ruff-0.15.11-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:0e783b599b4577788dbbb66b9addcef87e9a8832f4ce0c19e34bf55543a2f890", size = 10633136, upload-time = "2026-04-16T18:46:39.802Z" },
-    { url = "https://files.pythonhosted.org/packages/5b/53/3985a4f185020c2f367f2e08a103032e12564829742a1b417980ce1514a0/ruff-0.15.11-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:ae90592246625ba4a34349d68ec28d4400d75182b71baa196ddb9f82db025ef5", size = 10424701, upload-time = "2026-04-16T18:46:10.381Z" },
-    { url = "https://files.pythonhosted.org/packages/d3/57/bf0dfb32241b56c83bb663a826133da4bf17f682ba8c096973065f6e6a68/ruff-0.15.11-py3-none-musllinux_1_2_i686.whl", hash = "sha256:1f111d62e3c983ed20e0ca2e800f8d77433a5b1161947df99a5c2a3fb60514f0", size = 10873887, upload-time = "2026-04-16T18:46:29.157Z" },
-    { url = "https://files.pythonhosted.org/packages/02/05/e48076b2a57dc33ee8c7a957296f97c744ca891a8ffb4ffb1aaa3b3f517d/ruff-0.15.11-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:06f483d6646f59eaffba9ae30956370d3a886625f511a3108994000480621d1c", size = 11404316, upload-time = "2026-04-16T18:46:19.462Z" },
-    { url = "https://files.pythonhosted.org/packages/88/27/0195d15fe7a897cbcba0904792c4b7c9fdd958456c3a17d2ea6093716a9a/ruff-0.15.11-py3-none-win32.whl", hash = "sha256:476a2aa56b7da0b73a3ee80b6b2f0e19cce544245479adde7baa65466664d5f3", size = 10655535, upload-time = "2026-04-16T18:46:12.47Z" },
-    { url = "https://files.pythonhosted.org/packages/3a/5e/c927b325bd4c1d3620211a4b96f47864633199feed60fa936025ab27e090/ruff-0.15.11-py3-none-win_amd64.whl", hash = "sha256:8b6756d88d7e234fb0c98c91511aae3cd519d5e3ed271cae31b20f39cb2a12a3", size = 11779692, upload-time = "2026-04-16T18:46:17.268Z" },
-    { url = "https://files.pythonhosted.org/packages/63/b6/aeadee5443e49baa2facd51131159fd6301cc4ccfc1541e4df7b021c37dd/ruff-0.15.11-py3-none-win_arm64.whl", hash = "sha256:063fed18cc1bbe0ee7393957284a6fe8b588c6a406a285af3ee3f46da2391ee4", size = 11032614, upload-time = "2026-04-16T18:46:34.487Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/00/a1c2fdc9939b2c03691edbda290afcd297f1f389196172826b03d6b6a595/ruff-0.15.10-py3-none-linux_armv6l.whl", hash = "sha256:0744e31482f8f7d0d10a11fcbf897af272fefdfcb10f5af907b18c2813ff4d5f", size = 10563362, upload-time = "2026-04-09T14:06:21.189Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/15/006990029aea0bebe9d33c73c3e28c80c391ebdba408d1b08496f00d422d/ruff-0.15.10-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:b1e7c16ea0ff5a53b7c2df52d947e685973049be1cdfe2b59a9c43601897b22e", size = 10951122, upload-time = "2026-04-09T14:06:02.236Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/c0/4ac978fe874d0618c7da647862afe697b281c2806f13ce904ad652fa87e4/ruff-0.15.10-py3-none-macosx_11_0_arm64.whl", hash = "sha256:93cc06a19e5155b4441dd72808fdf84290d84ad8a39ca3b0f994363ade4cebb1", size = 10314005, upload-time = "2026-04-09T14:06:00.026Z" },
+    { url = "https://files.pythonhosted.org/packages/da/73/c209138a5c98c0d321266372fc4e33ad43d506d7e5dd817dd89b60a8548f/ruff-0.15.10-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:83e1dd04312997c99ea6965df66a14fb4f03ba978564574ffc68b0d61fd3989e", size = 10643450, upload-time = "2026-04-09T14:05:42.137Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/76/0deec355d8ec10709653635b1f90856735302cb8e149acfdf6f82a5feb70/ruff-0.15.10-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:8154d43684e4333360fedd11aaa40b1b08a4e37d8ffa9d95fee6fa5b37b6fab1", size = 10379597, upload-time = "2026-04-09T14:05:49.984Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/be/86bba8fc8798c081e28a4b3bb6d143ccad3fd5f6f024f02002b8f08a9fa3/ruff-0.15.10-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:8ab88715f3a6deb6bde6c227f3a123410bec7b855c3ae331b4c006189e895cef", size = 11146645, upload-time = "2026-04-09T14:06:12.246Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/89/140025e65911b281c57be1d385ba1d932c2366ca88ae6663685aed8d4881/ruff-0.15.10-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a768ff5969b4f44c349d48edf4ab4f91eddb27fd9d77799598e130fb628aa158", size = 12030289, upload-time = "2026-04-09T14:06:04.776Z" },
+    { url = "https://files.pythonhosted.org/packages/88/de/ddacca9545a5e01332567db01d44bd8cf725f2db3b3d61a80550b48308ea/ruff-0.15.10-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:0ee3ef42dab7078bda5ff6a1bcba8539e9857deb447132ad5566a038674540d0", size = 11496266, upload-time = "2026-04-09T14:05:55.485Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/bb/7ddb00a83760ff4a83c4e2fc231fd63937cc7317c10c82f583302e0f6586/ruff-0.15.10-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:51cb8cc943e891ba99989dd92d61e29b1d231e14811db9be6440ecf25d5c1609", size = 11256418, upload-time = "2026-04-09T14:05:57.69Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/8d/55de0d35aacf6cd50b6ee91ee0f291672080021896543776f4170fc5c454/ruff-0.15.10-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:e59c9bdc056a320fb9ea1700a8d591718b8faf78af065484e801258d3a76bc3f", size = 11288416, upload-time = "2026-04-09T14:05:44.695Z" },
+    { url = "https://files.pythonhosted.org/packages/68/cf/9438b1a27426ec46a80e0a718093c7f958ef72f43eb3111862949ead3cc1/ruff-0.15.10-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:136c00ca2f47b0018b073f28cb5c1506642a830ea941a60354b0e8bc8076b151", size = 10621053, upload-time = "2026-04-09T14:05:52.782Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/50/e29be6e2c135e9cd4cb15fbade49d6a2717e009dff3766dd080fcb82e251/ruff-0.15.10-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:8b80a2f3c9c8a950d6237f2ca12b206bccff626139be9fa005f14feb881a1ae8", size = 10378302, upload-time = "2026-04-09T14:06:14.361Z" },
+    { url = "https://files.pythonhosted.org/packages/18/2f/e0b36a6f99c51bb89f3a30239bc7bf97e87a37ae80aa2d6542d6e5150364/ruff-0.15.10-py3-none-musllinux_1_2_i686.whl", hash = "sha256:e3e53c588164dc025b671c9df2462429d60357ea91af7e92e9d56c565a9f1b07", size = 10850074, upload-time = "2026-04-09T14:06:16.581Z" },
+    { url = "https://files.pythonhosted.org/packages/11/08/874da392558ce087a0f9b709dc6ec0d60cbc694c1c772dab8d5f31efe8cb/ruff-0.15.10-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:b0c52744cf9f143a393e284125d2576140b68264a93c6716464e129a3e9adb48", size = 11358051, upload-time = "2026-04-09T14:06:18.948Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/46/602938f030adfa043e67112b73821024dc79f3ab4df5474c25fa4c1d2d14/ruff-0.15.10-py3-none-win32.whl", hash = "sha256:d4272e87e801e9a27a2e8df7b21011c909d9ddd82f4f3281d269b6ba19789ca5", size = 10588964, upload-time = "2026-04-09T14:06:07.14Z" },
+    { url = "https://files.pythonhosted.org/packages/25/b6/261225b875d7a13b33a6d02508c39c28450b2041bb01d0f7f1a83d569512/ruff-0.15.10-py3-none-win_amd64.whl", hash = "sha256:28cb32d53203242d403d819fd6983152489b12e4a3ae44993543d6fe62ab42ed", size = 11745044, upload-time = "2026-04-09T14:05:39.473Z" },
+    { url = "https://files.pythonhosted.org/packages/58/ed/dea90a65b7d9e69888890fb14c90d7f51bf0c1e82ad800aeb0160e4bacfd/ruff-0.15.10-py3-none-win_arm64.whl", hash = "sha256:601d1610a9e1f1c2165a4f561eeaa2e2ea1e97f3287c5aa258d3dab8b57c6188", size = 11035607, upload-time = "2026-04-09T14:05:47.593Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -58,6 +58,7 @@ dev = [
     { name = "prek" },
     { name = "pyinstaller" },
     { name = "pytest" },
+    { name = "ruff" },
 ]
 
 [package.metadata]
@@ -69,6 +70,7 @@ dev = [
     { name = "prek" },
     { name = "pyinstaller" },
     { name = "pytest", specifier = ">=8.0.0" },
+    { name = "ruff", specifier = ">=0.15.11" },
 ]
 
 [[package]]
@@ -218,6 +220,31 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/85/9f/01a1a99704853cb63f253eea009390c88e7131c67e66a0a02099a8c917cb/pywin32-ctypes-0.2.3.tar.gz", hash = "sha256:d162dc04946d704503b2edc4d55f3dba5c1d539ead017afa00142c38b9885755", size = 29471, upload-time = "2024-08-14T10:15:34.626Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/de/3d/8161f7711c017e01ac9f008dfddd9410dff3674334c233bde66e7ba65bbf/pywin32_ctypes-0.2.3-py3-none-any.whl", hash = "sha256:8a1513379d709975552d202d942d9837758905c8d01eb82b8bcc30918929e7b8", size = 30756, upload-time = "2024-08-14T10:15:33.187Z" },
+]
+
+[[package]]
+name = "ruff"
+version = "0.15.11"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e4/8d/192f3d7103816158dfd5ea50d098ef2aec19194e6cbccd4b3485bdb2eb2d/ruff-0.15.11.tar.gz", hash = "sha256:f092b21708bf0e7437ce9ada249dfe688ff9a0954fc94abab05dcea7dcd29c33", size = 4637264, upload-time = "2026-04-16T18:46:26.58Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/02/1e/6aca3427f751295ab011828e15e9bf452200ac74484f1db4be0197b8170b/ruff-0.15.11-py3-none-linux_armv6l.whl", hash = "sha256:e927cfff503135c558eb581a0c9792264aae9507904eb27809cdcff2f2c847b7", size = 10607943, upload-time = "2026-04-16T18:46:05.967Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/26/1341c262e74f36d4e84f3d6f4df0ac68cd53331a66bfc5080daa17c84c0b/ruff-0.15.11-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:7a1b5b2938d8f890b76084d4fa843604d787a912541eae85fd7e233398bbb73e", size = 10988592, upload-time = "2026-04-16T18:46:00.742Z" },
+    { url = "https://files.pythonhosted.org/packages/03/71/850b1d6ffa9564fbb6740429bad53df1094082fe515c8c1e74b6d8d05f18/ruff-0.15.11-py3-none-macosx_11_0_arm64.whl", hash = "sha256:d4176f3d194afbdaee6e41b9ccb1a2c287dba8700047df474abfbe773825d1cb", size = 10338501, upload-time = "2026-04-16T18:46:03.723Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/11/cc1284d3e298c45a817a6aadb6c3e1d70b45c9b36d8d9cce3387b495a03a/ruff-0.15.11-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3b17c886fb88203ced3afe7f14e8d5ae96e9d2f4ccc0ee66aa19f2c2675a27e4", size = 10670693, upload-time = "2026-04-16T18:46:41.941Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/9e/f8288b034ab72b371513c13f9a41d9ba3effac54e24bfb467b007daee2ca/ruff-0.15.11-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:49fafa220220afe7758a487b048de4c8f9f767f37dfefad46b9dd06759d003eb", size = 10416177, upload-time = "2026-04-16T18:46:21.717Z" },
+    { url = "https://files.pythonhosted.org/packages/85/71/504d79abfd3d92532ba6bbe3d1c19fada03e494332a59e37c7c2dabae427/ruff-0.15.11-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f2ab8427e74a00d93b8bda1307b1e60970d40f304af38bccb218e056c220120d", size = 11221886, upload-time = "2026-04-16T18:46:15.086Z" },
+    { url = "https://files.pythonhosted.org/packages/43/5a/947e6ab7a5ad603d65b474be15a4cbc6d29832db5d762cd142e4e3a74164/ruff-0.15.11-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:195072c0c8e1fc8f940652073df082e37a5d9cb43b4ab1e4d0566ab8977a13b7", size = 12075183, upload-time = "2026-04-16T18:46:07.944Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/a1/0b7bb6268775fdd3a0818aee8efd8f5b4e231d24dd4d528ced2534023182/ruff-0.15.11-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a3a0996d486af3920dec930a2e7daed4847dfc12649b537a9335585ada163e9e", size = 11516575, upload-time = "2026-04-16T18:46:31.687Z" },
+    { url = "https://files.pythonhosted.org/packages/30/c3/bb5168fc4d233cc06e95f482770d0f3c87945a0cd9f614b90ea8dc2f2833/ruff-0.15.11-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1bef2cb556d509259f1fe440bb9cd33c756222cf0a7afe90d15edf0866702431", size = 11306537, upload-time = "2026-04-16T18:46:36.988Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/92/4cfae6441f3967317946f3b788136eecf093729b94d6561f963ed810c82e/ruff-0.15.11-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:030d921a836d7d4a12cf6e8d984a88b66094ccb0e0f17ddd55067c331191bf19", size = 11296813, upload-time = "2026-04-16T18:46:24.182Z" },
+    { url = "https://files.pythonhosted.org/packages/43/26/972784c5dde8313acde8ac71ba8ac65475b85db4a2352a76c9934361f9bc/ruff-0.15.11-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:0e783b599b4577788dbbb66b9addcef87e9a8832f4ce0c19e34bf55543a2f890", size = 10633136, upload-time = "2026-04-16T18:46:39.802Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/53/3985a4f185020c2f367f2e08a103032e12564829742a1b417980ce1514a0/ruff-0.15.11-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:ae90592246625ba4a34349d68ec28d4400d75182b71baa196ddb9f82db025ef5", size = 10424701, upload-time = "2026-04-16T18:46:10.381Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/57/bf0dfb32241b56c83bb663a826133da4bf17f682ba8c096973065f6e6a68/ruff-0.15.11-py3-none-musllinux_1_2_i686.whl", hash = "sha256:1f111d62e3c983ed20e0ca2e800f8d77433a5b1161947df99a5c2a3fb60514f0", size = 10873887, upload-time = "2026-04-16T18:46:29.157Z" },
+    { url = "https://files.pythonhosted.org/packages/02/05/e48076b2a57dc33ee8c7a957296f97c744ca891a8ffb4ffb1aaa3b3f517d/ruff-0.15.11-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:06f483d6646f59eaffba9ae30956370d3a886625f511a3108994000480621d1c", size = 11404316, upload-time = "2026-04-16T18:46:19.462Z" },
+    { url = "https://files.pythonhosted.org/packages/88/27/0195d15fe7a897cbcba0904792c4b7c9fdd958456c3a17d2ea6093716a9a/ruff-0.15.11-py3-none-win32.whl", hash = "sha256:476a2aa56b7da0b73a3ee80b6b2f0e19cce544245479adde7baa65466664d5f3", size = 10655535, upload-time = "2026-04-16T18:46:12.47Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/5e/c927b325bd4c1d3620211a4b96f47864633199feed60fa936025ab27e090/ruff-0.15.11-py3-none-win_amd64.whl", hash = "sha256:8b6756d88d7e234fb0c98c91511aae3cd519d5e3ed271cae31b20f39cb2a12a3", size = 11779692, upload-time = "2026-04-16T18:46:17.268Z" },
+    { url = "https://files.pythonhosted.org/packages/63/b6/aeadee5443e49baa2facd51131159fd6301cc4ccfc1541e4df7b021c37dd/ruff-0.15.11-py3-none-win_arm64.whl", hash = "sha256:063fed18cc1bbe0ee7393957284a6fe8b588c6a406a285af3ee3f46da2391ee4", size = 11032614, upload-time = "2026-04-16T18:46:34.487Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
Replaces flake8, black, and reorder-python-imports with Ruff for faster, unified linting and formatting. Adds YAML formatting and GitHub Actions validation. Updates build configuration for PEP 639 license compliance.

## Changes

### Tooling
- **Ruff migration**: Replaced `flake8` + `black` + `reorder-python-imports` with `ruff` and `ruff-format`
- **New hooks**: Added `yamlfmt` for YAML formatting and `actionlint` for GitHub Actions validation
- **Updated uv**: Bumped `uv-pre-commit` from 0.10.2 to 0.11.6

### Build & Packaging
- **PEP 639 compliance**: Changed `project.license` to SPDX expression (`"MIT"`) and added `license-files` to include LICENSE in distributions
- **Version bump**: 0.3.1 → 0.3.2
- **Python support**: Added classifiers for Python 3.13 and 3.14
- **Makefile**: Simplified pex build to use `uv run pex` instead of `uv tool run`\
- **Supply chain**: reduces supply chain risks by delaying new packages (uv and dependabot) for 7 days after release

### Code Quality
- Applied Ruff formatting across source and test files
- Fixed lingering `Pathlib` avoidance
- Updated yielding for-loops to use `yield from`
- Consolidated imports (Ruff's `I` rule)
- Removed deprecated license classifier

### New Files
- `.git-blame-ignore-revs`: Ignore formatting commits in git blame
- `.yamlfmt`: YAML formatting configuration

## Verification
- All 101 tests pass
- Pre-commit hooks pass (ruff, ruff-format, yamlfmt, actionlint, uv-lock)
- LICENSE file included in wheel and PEX distributions
