### PR TITLE
Implement better command aliases to avoid duped help outupt

### DIFF
--- a/src/gh_worktree/cli.py
+++ b/src/gh_worktree/cli.py
@@ -1,9 +1,31 @@
+import sys
+
 import fire
 
 from gh_worktree.main import WorktreeCommands
 
 
+def replace_alias(cli: WorktreeCommands):
+    """
+    Replaces an alias with its corresponding full subcommand name in the system
+    arguments if the provided subcommand is an alias.
+
+    This function inspects the command-line arguments and, if an alias is found
+    as the first subcommand, replaces it with the full subcommand name as defined
+    in the alias map of the provided `WorktreeCommands` instance.
+
+    :param cli: An instance of WorktreeCommands containing the alias map used to
+                resolve aliases to their corresponding full subcommand names.
+    """
+    subcommand = sys.argv[1] if len(sys.argv) > 1 else None
+    if subcommand is not None and subcommand in cli._alias_map.keys():
+        sys.argv[1] = cli._alias_map[subcommand]
+
+
 def main():
     """CLI tool for managing Git worktrees"""
-    commands = WorktreeCommands()
-    fire.Fire(commands, name="worktree")
+    component = WorktreeCommands()
+    replace_alias(component)
+    # we do not pass `name` here, because the CLI allows using an alias for the command. if name
+    # was passed, then using `worktree -- --completion` would use the wrong name for completion
+    fire.Fire(component=component)

--- a/src/gh_worktree/errors.py
+++ b/src/gh_worktree/errors.py
@@ -1,0 +1,4 @@
+class AliasConflictError(Exception):
+    """Thrown when there are conflicting aliases across subcommands"""
+
+    pass

--- a/src/gh_worktree/main.py
+++ b/src/gh_worktree/main.py
@@ -1,3 +1,5 @@
+from functools import cached_property
+
 from gh_worktree import __version__
 from gh_worktree.command import Command
 from gh_worktree.commands.checkout import CheckoutCommand
@@ -5,6 +7,7 @@ from gh_worktree.commands.create import CreateCommand
 from gh_worktree.commands.init import InitCommand
 from gh_worktree.commands.install import InstallCommand
 from gh_worktree.commands.remove import RemoveCommand
+from gh_worktree.errors import AliasConflictError
 from gh_worktree.runtime import Runtime
 
 
@@ -19,6 +22,7 @@ class WorktreeCommands(Command):
     def __init__(self):
         runtime = Runtime()
         super().__init__(runtime)
+        self._commands: list[Command] = []
         self._add(CreateCommand(self._runtime))
         self._add(CheckoutCommand(self._runtime))
         self._add(InitCommand(self._runtime))
@@ -32,10 +36,29 @@ class WorktreeCommands(Command):
 
         :param command: The command instance
         """
+        self._commands.append(command)
         setattr(self, command._name, command.__call__)
-        for alias in command._aliases:
-            setattr(self, alias, command.__call__)
+
+    @cached_property
+    def _alias_map(self) -> dict[str, str]:
+        alias_map = {}
+        for command in self._commands:
+            for alias in command._aliases:
+                if alias in alias_map:
+                    raise AliasConflictError(
+                        f"Command {command._name} wants alias {alias} "
+                        f"but it already exists for {alias_map[alias]}"
+                    )
+                alias_map[alias] = command._name
+        return alias_map
 
     def version(self):
-        """Outputs the version of gh-worktree"""
-        print(f"gh-worktree {__version__}")
+        """Outputs the version of the CLI"""
+        print(f"{self._name} {__version__}")
+
+    def aliases(self):
+        """Outputs all of the command aliases"""
+        for command in self._commands:
+            if len(command._aliases) == 0:
+                continue
+            print(f"{command._name}: {', '.join(command._aliases)}")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,55 @@
+from unittest import TestCase
+from unittest.mock import Mock, patch
+
+import gh_worktree.cli as cli_module
+from gh_worktree.cli import main, replace_alias
+
+
+class ReplaceAliasTestCase(TestCase):
+    @patch("gh_worktree.cli.sys.argv", ["gh-worktree", "rm", "feature-branch"])
+    def test_rewrites_first_arg_when_alias_exists(self):
+        cli = Mock()
+        cli._alias_map = {"rm": "remove"}
+
+        replace_alias(cli)
+
+        self.assertEqual("remove", cli._alias_map["rm"])
+        self.assertEqual("remove", cli_module.sys.argv[1])
+
+    @patch("gh_worktree.cli.sys.argv", ["gh-worktree", "remove", "feature-branch"])
+    def test_noop_when_arg_is_not_alias(self):
+        cli = Mock()
+        cli._alias_map = {"rm": "remove"}
+
+        replace_alias(cli)
+
+        self.assertEqual("remove", cli_module.sys.argv[1])
+
+    @patch("gh_worktree.cli.sys.argv", ["gh-worktree"])
+    def test_noop_when_no_subcommand(self):
+        cli = Mock()
+        cli._alias_map = {"rm": "remove"}
+
+        replace_alias(cli)
+
+        self.assertEqual(["gh-worktree"], cli_module.sys.argv)
+
+
+class MainTestCase(TestCase):
+    @patch("gh_worktree.cli.fire.Fire")
+    @patch("gh_worktree.cli.replace_alias")
+    @patch("gh_worktree.cli.WorktreeCommands")
+    def test_main__builds_component_replaces_aliases_and_invokes_fire(
+        self,
+        commands_cls_mock,
+        replace_alias_mock,
+        fire_mock,
+    ):
+        component = Mock()
+        commands_cls_mock.return_value = component
+
+        main()
+
+        commands_cls_mock.assert_called_once_with()
+        replace_alias_mock.assert_called_once_with(component)
+        fire_mock.assert_called_once_with(component=component)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,48 @@
+from types import SimpleNamespace
+from unittest import TestCase
+from unittest.mock import patch
+
+import gh_worktree.main as main_module
+from gh_worktree.errors import AliasConflictError
+from gh_worktree.main import WorktreeCommands
+
+
+class WorktreeCommandsTestCase(TestCase):
+    def setUp(self):
+        self.commands = WorktreeCommands()
+
+    def test_add__registers_command_name_but_not_alias(self):
+        self.assertTrue(callable(self.commands.remove))
+        self.assertFalse(hasattr(self.commands, "rm"))
+
+    def test_alias_map__contains_remove_alias_mapping(self):
+        alias_map = self.commands._alias_map
+
+        self.assertIn("rm", alias_map)
+        self.assertEqual(alias_map["rm"], "remove")
+
+    def test_alias_map__raises_when_aliases_conflict(self):
+        self.commands._commands.append(SimpleNamespace(_name="duplicate", _aliases=["rm"]))
+
+        with self.assertRaisesRegex(
+            AliasConflictError,
+            "Command duplicate wants alias rm but it already exists for remove",
+        ):
+            _ = self.commands._alias_map
+
+    @patch("builtins.print")
+    def test_version__prints_cli_name_and_version(self, print_mock):
+        self.commands.version()
+
+        print_mock.assert_called_once_with(f"{self.commands._name} {main_module.__version__}")
+
+    @patch("builtins.print")
+    def test_aliases__prints_only_commands_with_aliases(self, print_mock):
+        self.commands._commands = [
+            SimpleNamespace(_name="create", _aliases=[]),
+            SimpleNamespace(_name="remove", _aliases=["rm"]),
+        ]
+
+        self.commands.aliases()
+
+        print_mock.assert_called_once_with("remove: rm")


### PR DESCRIPTION
## Summary
- dynamically replaces alias with full command in sys args
- corrects naming issue with built-in python-fire completion
- adds tests for changes