### PR TITLE
Implement custom error types

### DIFF
--- a/src/gh_worktree/cli.py
+++ b/src/gh_worktree/cli.py
@@ -22,10 +22,46 @@ def replace_alias(cli: WorktreeCommands):
         sys.argv[1] = cli._alias_map[subcommand]
 
 
+def replace_verbose():
+    """
+    Parses command-line arguments to determine if the verbose mode is enabled.
+
+    This function searches arguments before the passthrough separator (`--`) for
+    verbose flags (`-v` and `--verbose`). Matching flags are removed from
+    `sys.argv`, and verbose mode is considered enabled.
+
+    :return: A boolean indicating whether verbose mode is enabled.
+    """
+    is_verbose = False
+
+    passthrough_index = sys.argv.index("--") if "--" in sys.argv else len(sys.argv)
+    kept_args = [sys.argv[0]]
+
+    for arg in sys.argv[1:passthrough_index]:
+        if arg in ("-v", "--verbose"):
+            is_verbose = True
+            continue
+        kept_args.append(arg)
+
+    if passthrough_index < len(sys.argv):
+        kept_args.extend(sys.argv[passthrough_index:])
+
+    sys.argv[:] = kept_args
+    return is_verbose
+
+
 def main():
     """CLI tool for managing Git worktrees"""
-    component = WorktreeCommands()
+    is_verbose = replace_verbose()
+    component = WorktreeCommands(verbose=is_verbose)
     replace_alias(component)
-    # we do not pass `name` here, because the CLI allows using an alias for the command. if name
-    # was passed, then using `worktree -- --completion` would use the wrong name for completion
-    fire.Fire(component=component)
+
+    try:
+        # we do not pass `name` here, because the CLI allows using an alias for the command. if name
+        # was passed, then using `worktree -- --completion` would use the wrong name for completion
+        fire.Fire(component=component)
+    except Exception as e:
+        if is_verbose:
+            raise
+        print(f"\033[91m\nCommand failed: {str(e)}\033[0m")
+        sys.exit(1)

--- a/src/gh_worktree/commands/checkout.py
+++ b/src/gh_worktree/commands/checkout.py
@@ -2,6 +2,7 @@ import re
 from functools import cached_property
 
 from gh_worktree.command import Command
+from gh_worktree.errors import BranchInputError, CommandError, RemoteNotFoundError, RemoteUsageError
 from gh_worktree.hooks import Hook
 from gh_worktree.runtime import Runtime
 from gh_worktree.utils import normalize_worktree_name
@@ -24,12 +25,14 @@ class CheckoutInput:
             and not URL_RE.match(self.branch_or_pr)
             and not BRANCH_RE.match(self.branch_or_pr)
         ):
-            raise ValueError("Couldn't parse input. Must be branch name, PR number or PR URL.")
+            raise BranchInputError(
+                "Couldn't parse input. Must be branch name, PR number or PR URL."
+            )
 
         if self.remote_name is not None and (
             self.branch_or_pr.isdigit() or URL_RE.match(self.branch_or_pr)
         ):
-            raise ValueError("Remote name isn't allowed with PR number or PR URL.")
+            raise RemoteUsageError("Remote name isn't allowed with PR number or PR URL.")
 
     @cached_property
     def owner(self) -> str:
@@ -46,7 +49,7 @@ class CheckoutInput:
 
         remote = self.runtime.get_remote(name=self.remote_name)
         if not remote:
-            raise AssertionError("Couldn't find matching remote for --remote input")
+            raise RemoteNotFoundError("Couldn't find matching remote for --remote input")
 
         return remote.uri.replace("https://github.com/", "").split("/", 1)[0]
 
@@ -57,7 +60,7 @@ class CheckoutInput:
             return self.remote_name
         remote = self.runtime.get_remote(owner_name=self.owner)
         if not remote:
-            raise AssertionError("Couldn't find matching remote for PR")
+            raise RemoteNotFoundError("Couldn't find matching remote for PR")
         return remote.name
 
     @cached_property
@@ -120,7 +123,7 @@ class CheckoutCommand(Command):
             # TODO: is this good to detect if it's local only?
             try:
                 self._runtime.git.fetch(inpt.remote, f"{inpt.worktree_name}:{inpt.worktree_name}")
-            except RuntimeError:
+            except (CommandError, OSError):
                 print("Ignoring git fetch error, attempting to open worktree")
                 pass
 

--- a/src/gh_worktree/commands/init.py
+++ b/src/gh_worktree/commands/init.py
@@ -3,6 +3,7 @@ from urllib import parse
 
 from gh_worktree.command import Command
 from gh_worktree.config import RepositoryConfig
+from gh_worktree.errors import ProjectExistsError, RepositoryPathError
 from gh_worktree.hooks import Hook, HookExists
 from gh_worktree.templates import TemplateExists
 
@@ -13,7 +14,7 @@ GIT_EXT_RE = re.compile(r"\.git$")
 def normalize(repo: str):
     if not repo.startswith("http") and not repo.startswith("git@"):
         if not JUST_PATH_RE.match(repo):
-            raise ValueError("Invalid repository path format. Expected: {owner}/{repo}")
+            raise RepositoryPathError("Invalid repository path format. Expected: {owner}/{repo}")
         repo = f"https://github.com/{repo}"
 
     if not repo.endswith(".git"):
@@ -30,7 +31,7 @@ class RepositoryTarget:
     def validate(self):
         path_parts = self.path.split("/")
         if len(path_parts) != 2:
-            raise ValueError(f"Invalid repository path: {self.path}")
+            raise RepositoryPathError(f"Invalid repository path: {self.path}")
 
     @property
     def path(self):
@@ -90,7 +91,7 @@ class InitCommand(Command):
 
         if project_dir.exists():
             # this would be problematic!
-            raise AssertionError(f"Project directory {project_dir} already exists")
+            raise ProjectExistsError(f"Project directory {project_dir} already exists")
 
         project_dir.mkdir(parents=True, exist_ok=True)
 

--- a/src/gh_worktree/commands/remove.py
+++ b/src/gh_worktree/commands/remove.py
@@ -1,4 +1,5 @@
 from gh_worktree.command import Command
+from gh_worktree.errors import WorktreeNotFoundError
 from gh_worktree.hooks import Hook
 from gh_worktree.utils import normalize_worktree_name
 
@@ -27,7 +28,7 @@ class RemoveCommand(Command):
         """
         project_dir = self._context.project_dir
         if not (project_dir / worktree_name).exists():
-            raise ValueError(f"Worktree {worktree_name} does not exist")
+            raise WorktreeNotFoundError(f"Worktree {worktree_name} does not exist")
 
         normalized_name = normalize_worktree_name(worktree_name)
 

--- a/src/gh_worktree/config.py
+++ b/src/gh_worktree/config.py
@@ -1,5 +1,7 @@
 import json
 
+from gh_worktree.errors import ConfigTypeError
+
 
 class Config:
     type: str
@@ -18,7 +20,7 @@ class Config:
         config = cls()
         config_data = json.load(fd)
         if config_data["type"] != cls.type:
-            raise ValueError(f"Invalid config type: {config_data['type']}")
+            raise ConfigTypeError(f"Invalid config type: {config_data['type']}")
         config._data = config_data
         return config
 

--- a/src/gh_worktree/context.py
+++ b/src/gh_worktree/context.py
@@ -3,6 +3,7 @@ from contextlib import contextmanager
 from pathlib import Path
 
 from gh_worktree.config import Config, GlobalConfig, RepositoryConfig
+from gh_worktree.errors import AncestorNotFoundError, ConfigTypeError, ProjectNotFoundError
 from gh_worktree.utils import find_up
 
 
@@ -26,13 +27,13 @@ class Context:
     def global_config_dir(self) -> Path:
         try:
             parent_dir = self.project_dir.parent
-        except RuntimeError:
+        except AncestorNotFoundError:
             parent_dir = self.cwd.parent
 
         try:
             closest_gh_dir = find_up(".gh", parent_dir)
             return closest_gh_dir / "worktree"
-        except RuntimeError:
+        except AncestorNotFoundError:
             # default to ~/.gh/worktree
             return Path.home() / ".gh" / "worktree"
 
@@ -55,8 +56,8 @@ class Context:
     def assert_within_project(self):
         try:
             find_up(".bare", self.cwd)
-        except RuntimeError as e:
-            raise AssertionError("Project not found") from e
+        except AncestorNotFoundError as e:
+            raise ProjectNotFoundError("Project not found") from e
 
     def get_config(self) -> RepositoryConfig:
         file_path = self.config_dir / "config.json"
@@ -80,7 +81,7 @@ class Context:
         elif isinstance(config, GlobalConfig):
             config_dir = self.global_config_dir
         else:
-            raise ValueError(f"Unknown config type: {type(config)}")
+            raise ConfigTypeError(f"Unknown config type: {type(config)}")
 
         config_dir.mkdir(parents=True, exist_ok=True)
         with (config_dir / "config.json").open("w", encoding="utf-8") as f:

--- a/src/gh_worktree/errors.py
+++ b/src/gh_worktree/errors.py
@@ -1,4 +1,117 @@
-class AliasConflictError(Exception):
-    """Thrown when there are conflicting aliases across subcommands"""
+class WorktreeError(Exception):
+    """Base exception for all gh-worktree errors"""
+
+    pass
+
+
+# Validation errors - invalid user input
+class ValidationError(WorktreeError):
+    """Raised when user input is invalid or malformed"""
+
+    pass
+
+
+class WorktreeNameError(ValidationError):
+    """Raised when worktree name is invalid"""
+
+    pass
+
+
+class BranchInputError(ValidationError):
+    """Raised when branch/PR input cannot be parsed"""
+
+    pass
+
+
+class RepositoryPathError(ValidationError):
+    """Raised when repository path/URL is invalid"""
+
+    pass
+
+
+class ConfigTypeError(ValidationError):
+    """Raised when config type is invalid or mismatched"""
+
+    pass
+
+
+class RemoteUsageError(ValidationError):
+    """Raised when remote is used incorrectly"""
+
+    pass
+
+
+# Not found errors - resources don't exist
+class NotFoundError(WorktreeError):
+    """Raised when a required resource is not found"""
+
+    pass
+
+
+class ProjectNotFoundError(NotFoundError):
+    """Raised when project directory is not found"""
+
+    pass
+
+
+class WorktreeNotFoundError(NotFoundError):
+    """Raised when worktree doesn't exist"""
+
+    pass
+
+
+class RemoteNotFoundError(NotFoundError):
+    """Raised when git remote is not found"""
+
+    pass
+
+
+class AncestorNotFoundError(NotFoundError):
+    """Raised when file/directory not found in ancestor paths"""
+
+    pass
+
+
+# Conflict errors - resource already exists
+class ConflictError(WorktreeError):
+    """Raised when resource already exists"""
+
+    pass
+
+
+# Hook errors
+class HookError(WorktreeError):
+    """Raised when hook execution fails"""
+
+    pass
+
+
+class HookExistsError(HookError, ConflictError):
+    """Raised when hook already exists"""
+
+    pass
+
+
+class ProjectExistsError(ConflictError):
+    """Raised when project directory already exists"""
+
+    pass
+
+
+class AliasConflictError(ConflictError):
+    """Raised when there are conflicting aliases across subcommands"""
+
+    pass
+
+
+class TemplateExistsError(ConflictError):
+    """Raised when template already exists"""
+
+    pass
+
+
+# Command errors - git/command execution failures
+class CommandError(WorktreeError):
+    """Raised when a git or shell command fails"""
 
     pass

--- a/src/gh_worktree/git.py
+++ b/src/gh_worktree/git.py
@@ -2,6 +2,7 @@ import re
 from collections import namedtuple
 
 from gh_worktree.context import Context
+from gh_worktree.errors import CommandError, WorktreeNameError
 from gh_worktree.utils import iter_output, stream_exec
 
 TYPE_RE = re.compile(r"\((.*)\)")
@@ -16,7 +17,7 @@ class GitCLI:
     def _stream_exec(self, *command: str):
         return_status = stream_exec(["git", *command], cwd=self.context.cwd)
         if return_status != 0:
-            raise RuntimeError(
+            raise CommandError(
                 f"Command failed, with exit status {return_status}: git {' '.join(command)}"
             )
 
@@ -57,7 +58,7 @@ class GitCLI:
     def open_worktree(self, name: str):
         """Create a new worktree from an existing branch"""
         if ".." in name or name.startswith("/"):
-            raise ValueError("Worktree name cannot contain '..' or start with '/'")
+            raise WorktreeNameError("Worktree name cannot contain '..' or start with '/'")
         # `git worktree add <path>` creates a new branch from HEAD. To use an
         # existing branch, the command is `git worktree add <path> <branch>`.
         # We pass `name` for both to check out the existing branch in a path with the same name.

--- a/src/gh_worktree/hooks.py
+++ b/src/gh_worktree/hooks.py
@@ -6,6 +6,7 @@ from enum import Enum
 from pathlib import Path
 
 from gh_worktree.context import Context
+from gh_worktree.errors import HookError, HookExistsError
 from gh_worktree.operator import ConfigOperator
 from gh_worktree.utils import COLOR_RESET, COLOR_YELLOW, stream_exec
 
@@ -25,7 +26,7 @@ class Hook(Enum):
         return f".gh/worktree/hooks/{self.name}"
 
 
-class HookExists(Exception):
+class HookExists(HookExistsError):
     pass
 
 
@@ -79,7 +80,7 @@ class Hooks(ConfigOperator):
             command_args = [hook_file_str, *[str(arg) for arg in args]]
             return_status = stream_exec(command_args, cwd=self.context.cwd)
             if return_status != 0:
-                raise RuntimeError(f"Hook {hook.name} failed with exit code {return_status}")
+                raise HookError(f"Hook {hook.name} failed with exit code {return_status}")
         return fired
 
     def _check_allowed(self, hook_file: Path, bypass_allowlist: bool = False) -> bool:

--- a/src/gh_worktree/main.py
+++ b/src/gh_worktree/main.py
@@ -19,8 +19,11 @@ class WorktreeCommands(Command):
 
     _name = "gh-worktree"
 
-    def __init__(self):
-        runtime = Runtime()
+    def __init__(self, verbose: bool = False):
+        """
+        :param verbose: Whether to enable logging verbosity
+        """
+        runtime = Runtime(verbose)
         super().__init__(runtime)
         self._commands: list[Command] = []
         self._add(CreateCommand(self._runtime))

--- a/src/gh_worktree/runtime.py
+++ b/src/gh_worktree/runtime.py
@@ -1,4 +1,5 @@
 from gh_worktree.context import Context
+from gh_worktree.errors import RemoteUsageError
 from gh_worktree.gh import GithubCLI
 from gh_worktree.git import GitCLI, GitRemote
 from gh_worktree.hooks import Hooks
@@ -27,7 +28,7 @@ class Runtime:
             # forks could be renamed, but we're not gonna worry about that for now
             remote_ref = f"{owner_name}/{config.name}"
         elif not name:
-            raise ValueError("Must provide either owner_name or name")
+            raise RemoteUsageError("Must provide either owner_name or name")
 
         for remote in self.git.remote():
             if remote.type != "fetch":

--- a/src/gh_worktree/runtime.py
+++ b/src/gh_worktree/runtime.py
@@ -7,9 +7,13 @@ from gh_worktree.templates import Templates
 
 
 class Runtime:
-    __slots__ = ("context", "hooks", "git", "gh", "templates")
+    __slots__ = ("verbose", "context", "hooks", "git", "gh", "templates")
 
-    def __init__(self):
+    def __init__(self, verbose: bool = False):
+        """
+        :param verbose: Whether to enable logging verbosity
+        """
+        self.verbose = verbose
         self.context = Context()
         self.hooks = Hooks(self.context)
         self.git = GitCLI(self.context)

--- a/src/gh_worktree/utils.py
+++ b/src/gh_worktree/utils.py
@@ -4,6 +4,8 @@ import shlex
 import subprocess
 from pathlib import Path
 
+from gh_worktree.errors import AncestorNotFoundError
+
 # Simple ANSI colors for the prefix
 COLOR_YELLOW = "\033[93m"
 COLORS = ["\033[92m", "\033[94m", "\033[95m", "\033[96m", COLOR_YELLOW]
@@ -27,7 +29,7 @@ def find_up(name: str, start_path: str | Path) -> Path:
             break
         search_path = search_path.parent
 
-    raise RuntimeError(f"Could not find {name} in {start_path} ancestors")
+    raise AncestorNotFoundError(f"Could not find {name} in {start_path} ancestors")
 
 
 def _log_prefix(command: list[str]) -> str:

--- a/tests/commands/test_checkout.py
+++ b/tests/commands/test_checkout.py
@@ -5,6 +5,7 @@ from unittest import TestCase
 from unittest.mock import ANY, Mock
 
 from gh_worktree.commands.checkout import CheckoutCommand
+from gh_worktree.errors import BranchInputError, CommandError, RemoteNotFoundError
 from gh_worktree.git import GitRemote
 from gh_worktree.hooks import Hook
 
@@ -121,11 +122,11 @@ class CheckoutCommandTestCase(TestCase):
     def test_call__raises_on_missing_remote(self):
         self.runtime.get_remote.return_value = None
 
-        with self.assertRaises(AssertionError, msg="Couldn't find matching remote"):
+        with self.assertRaises(RemoteNotFoundError, msg="Couldn't find matching remote"):
             self.command("feature")
 
     def test_call__rejects_invalid_pull_url(self):
-        with self.assertRaises(ValueError, msg="Couldn't parse input. Must be"):
+        with self.assertRaises(BranchInputError, msg="Couldn't parse input. Must be"):
             self.command("https://github.com/octo/repo/issues/12")
 
     def test_call__yes_true_sets_bypass_allowlist_true(self):
@@ -141,3 +142,10 @@ class CheckoutCommandTestCase(TestCase):
         self.hooks.fire.assert_any_call(
             Hook.post_checkout, "feature", ANY, "feature", bypass_allowlist=True
         )
+
+    def test_call__ignores_fetch_error(self):
+        self.git.fetch.side_effect = CommandError("fetch failed")
+
+        self.command("feature")
+
+        self.git.open_worktree.assert_called_once_with("feature")

--- a/tests/commands/test_init.py
+++ b/tests/commands/test_init.py
@@ -6,6 +6,7 @@ from unittest import TestCase
 from unittest.mock import MagicMock, Mock
 
 from gh_worktree.commands.init import InitCommand, RepositoryTarget, normalize
+from gh_worktree.errors import RepositoryPathError
 from gh_worktree.hooks import Hook
 
 
@@ -45,7 +46,7 @@ class NormalizeTestCase(TestCase):
         )
 
     def test_invalid_repo(self):
-        with self.assertRaisesRegex(ValueError, "Invalid repository path format"):
+        with self.assertRaisesRegex(RepositoryPathError, "Invalid repository path format"):
             normalize("not a repo")
 
 
@@ -56,7 +57,9 @@ class RepositoryTargetTestCase(TestCase):
 
     def test_validate__invalid_path(self):
         target = RepositoryTarget("https://github.com/octo/repo/pull/123.git")
-        with self.assertRaises(ValueError, msg="Invalid repository path: octo/repo/pull/123"):
+        with self.assertRaises(
+            RepositoryPathError, msg="Invalid repository path: octo/repo/pull/123"
+        ):
             target.validate()
 
     def test_path__url(self):

--- a/tests/commands/test_remove.py
+++ b/tests/commands/test_remove.py
@@ -6,6 +6,7 @@ from unittest import TestCase
 from unittest.mock import Mock
 
 from gh_worktree.commands.remove import RemoveCommand
+from gh_worktree.errors import WorktreeNotFoundError
 from gh_worktree.hooks import Hook
 
 
@@ -36,7 +37,7 @@ class RemoveCommandTestCase(TestCase):
 
         command = RemoveCommand(runtime)
 
-        with self.assertRaisesRegex(ValueError, "Worktree missing does not exist"):
+        with self.assertRaisesRegex(WorktreeNotFoundError, "Worktree missing does not exist"):
             command("missing")
 
     def test_call__runs_hooks_and_git(self):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,7 +2,7 @@ from unittest import TestCase
 from unittest.mock import Mock, patch
 
 import gh_worktree.cli as cli_module
-from gh_worktree.cli import main, replace_alias
+from gh_worktree.cli import main, replace_alias, replace_verbose
 
 
 class ReplaceAliasTestCase(TestCase):
@@ -38,18 +38,71 @@ class ReplaceAliasTestCase(TestCase):
 class MainTestCase(TestCase):
     @patch("gh_worktree.cli.fire.Fire")
     @patch("gh_worktree.cli.replace_alias")
+    @patch("gh_worktree.cli.replace_verbose")
     @patch("gh_worktree.cli.WorktreeCommands")
     def test_main__builds_component_replaces_aliases_and_invokes_fire(
         self,
         commands_cls_mock,
+        replace_verbose_mock,
         replace_alias_mock,
         fire_mock,
     ):
         component = Mock()
         commands_cls_mock.return_value = component
+        replace_verbose_mock.return_value = False
 
         main()
 
-        commands_cls_mock.assert_called_once_with()
+        replace_verbose_mock.assert_called_once_with()
+        commands_cls_mock.assert_called_once_with(verbose=False)
         replace_alias_mock.assert_called_once_with(component)
         fire_mock.assert_called_once_with(component=component)
+
+
+class ReplaceVerboseTestCase(TestCase):
+    @patch("gh_worktree.cli.sys.argv", ["gh-worktree", "-v", "remove", "feature"])
+    def test_rewrites_args_and_returns_true_for_short_flag(self):
+        is_verbose = replace_verbose()
+
+        self.assertTrue(is_verbose)
+        self.assertEqual(["gh-worktree", "remove", "feature"], cli_module.sys.argv)
+
+    @patch(
+        "gh_worktree.cli.sys.argv",
+        ["gh-worktree", "--verbose", "remove", "feature"],
+    )
+    def test_rewrites_args_and_returns_true_for_long_flag(self):
+        is_verbose = replace_verbose()
+
+        self.assertTrue(is_verbose)
+        self.assertEqual(["gh-worktree", "remove", "feature"], cli_module.sys.argv)
+
+    @patch(
+        "gh_worktree.cli.sys.argv",
+        ["gh-worktree", "-v", "--verbose", "remove", "feature"],
+    )
+    def test_consumes_all_verbose_flags_before_passthrough_separator(self):
+        is_verbose = replace_verbose()
+
+        self.assertTrue(is_verbose)
+        self.assertEqual(["gh-worktree", "remove", "feature"], cli_module.sys.argv)
+
+    @patch(
+        "gh_worktree.cli.sys.argv",
+        ["gh-worktree", "remove", "--", "--verbose", "-v", "feature"],
+    )
+    def test_does_not_strip_verbose_flags_after_passthrough_separator(self):
+        is_verbose = replace_verbose()
+
+        self.assertFalse(is_verbose)
+        self.assertEqual(
+            ["gh-worktree", "remove", "--", "--verbose", "-v", "feature"],
+            cli_module.sys.argv,
+        )
+
+    @patch("gh_worktree.cli.sys.argv", ["gh-worktree", "remove", "feature"])
+    def test_noop_when_no_verbose_flag_is_present(self):
+        is_verbose = replace_verbose()
+
+        self.assertFalse(is_verbose)
+        self.assertEqual(["gh-worktree", "remove", "feature"], cli_module.sys.argv)

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -1,0 +1,43 @@
+import tempfile
+from pathlib import Path
+from unittest import TestCase
+
+from gh_worktree.context import Context
+from gh_worktree.errors import ProjectNotFoundError
+
+
+class ContextTestCase(TestCase):
+    def setUp(self):
+        self.tmp_dir = tempfile.TemporaryDirectory()
+        self.tmp_path = Path(self.tmp_dir.name)
+        self.context = Context()
+        self.context.cwd = self.tmp_path
+
+    def tearDown(self):
+        self.tmp_dir.cleanup()
+
+    def test_assert_within_project__success(self):
+        (self.tmp_path / ".bare").mkdir()
+
+        self.context.assert_within_project()
+
+    def test_assert_within_project__failure(self):
+        with self.assertRaises(ProjectNotFoundError):
+            self.context.assert_within_project()
+
+    def test_project_dir__cached(self):
+        (self.tmp_path / ".bare").mkdir()
+
+        project_dir = self.context.project_dir
+        self.assertEqual(project_dir, self.tmp_path)
+
+        project_dir_again = self.context.project_dir
+        self.assertIs(project_dir_again, project_dir)
+
+    def test_reset_properties(self):
+        (self.tmp_path / ".bare").mkdir()
+
+        _ = self.context.project_dir
+        self.context.reset_properties()
+
+        self.assertIsNone(self.context._cached_project_dir)

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -2,6 +2,7 @@ from pathlib import Path
 from types import SimpleNamespace
 from unittest import TestCase, mock
 
+from gh_worktree.errors import CommandError, WorktreeNameError
 from gh_worktree.git import GitCLI, GitRemote
 
 
@@ -25,7 +26,7 @@ class GitCLITestCase(TestCase):
 
     def test_stream_exec__fail(self):
         self.mock_stream_exec.return_value = 1
-        with self.assertRaises(RuntimeError):
+        with self.assertRaises(CommandError):
             self.cli._stream_exec("foo", "bar")
         self.mock_stream_exec.assert_called_once_with(["git", "foo", "bar"], cwd=Path("/test/tmp"))
 
@@ -119,9 +120,9 @@ class GitCLITestCase(TestCase):
         )
 
     def test_open_worktree_validation(self):
-        with self.assertRaises(ValueError):
+        with self.assertRaises(WorktreeNameError):
             self.cli.open_worktree("../outside")
-        with self.assertRaises(ValueError):
+        with self.assertRaises(WorktreeNameError):
             self.cli.open_worktree("/absolute")
 
     def test_remove_worktree(self):

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -6,7 +6,8 @@ from pathlib import Path
 from unittest import TestCase, mock
 
 from gh_worktree.context import Context
-from gh_worktree.hooks import Hook, HookExists, Hooks
+from gh_worktree.errors import HookExistsError
+from gh_worktree.hooks import Hook, Hooks
 
 
 class HooksTestCase(TestCase):
@@ -110,6 +111,6 @@ class HooksTestCase(TestCase):
         hook_file = self.hooks_path / Hook.pre_init.name
         hook_file.write_bytes(b"echo ok")
 
-        with self.assertRaises(HookExists):
+        with self.assertRaises(HookExistsError):
             with self.hooks.add(Hook.pre_init) as f:
                 f.write("echo ok")

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -1,6 +1,7 @@
 from types import SimpleNamespace
 from unittest import TestCase
 
+from gh_worktree.errors import RemoteUsageError
 from gh_worktree.git import GitRemote
 from gh_worktree.runtime import Runtime
 
@@ -20,7 +21,7 @@ class RuntimeTestCase(TestCase):
         self.runtime.git = SimpleNamespace(remote=lambda: self.remotes)
 
     def test_get_remote__no_args_raises(self):
-        with self.assertRaises(ValueError, msg="Must provide either owner_name or name"):
+        with self.assertRaises(RemoteUsageError, msg="Must provide either owner_name or name"):
             self.runtime.get_remote()
 
     def test_get_remote__owner_name(self):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,6 +2,7 @@ import tempfile
 from pathlib import Path
 from unittest import TestCase
 
+from gh_worktree.errors import AncestorNotFoundError
 from gh_worktree.utils import find_up, normalize_worktree_name
 
 
@@ -40,7 +41,7 @@ class FindUpTestCase(TestCase):
         subdir = root / "subdir"
         subdir.mkdir()
 
-        with self.assertRaisesRegex(RuntimeError, "Could not find non_existent_file"):
+        with self.assertRaisesRegex(AncestorNotFoundError, "Could not find non_existent_file"):
             find_up("non_existent_file", subdir)
 
 


### PR DESCRIPTION
## Summary

Replaces built-in exceptions (RuntimeError, ValueError, AssertionError) with a consolidated hierarchy of custom error types.

## Changes

### Error Hierarchy (src/gh_worktree/errors.py)

All errors inherit from `WorktreeError` base class, organized by category:

- **ValidationError** - Invalid user input
  - WorktreeNameError, BranchInputError, RepositoryPathError, ConfigTypeError, RemoteUsageError
- **NotFoundError** - Resources not found
  - ProjectNotFoundError, WorktreeNotFoundError, RemoteNotFoundError, AncestorNotFoundError
- **HookError** - Hook execution failures
- **HookExistsError** - Hook already exists
- **ConflictError** - Resource conflicts
  - ProjectExistsError, AliasConflictError, TemplateExistsError
- **CommandError** - Git/command execution failures

### Files Updated

- **Source files (8):** errors.py, context.py, utils.py, git.py, runtime.py, config.py, hooks.py, commands/\*
- **Test files (7):** Updated to expect new exception types

### Benefits

1. **Better error categorization** - Errors grouped by domain, not generic types
2. **Exception chaining preserved** - `raise ... from ...` used where applicable
3. **Easier error handling** - Callers can catch specific error types or `WorktreeError` base
4. **Clearer error messages** - Error type indicates category, message provides detail

## Testing

- All 110 tests pass
- Linting passes (prek, ruff)