### PR TITLE
Cleanup and refine logging output and format

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gh-worktree"
-version = "0.3.2"
+version = "0.4.0"
 description = "github CLI extension for worktrees"
 readme = "README.md"
 authors = [

--- a/src/gh_worktree/gh.py
+++ b/src/gh_worktree/gh.py
@@ -25,14 +25,16 @@ REPO_FIELDS = [
 class GithubCLI(SubprocessOperator):
     command_name = "gh"
 
-    def pr_status(self, pr_number: int | str, owner_repo: str | None = None):
+    def pr_status(self, pr_number: int | str, owner_repo: str | None = None) -> dict:
         args = ["pr", "view"]
         if owner_repo:
             args.extend(["--repo", owner_repo])
         args.extend(["--json", ",".join(PR_FIELDS), str(pr_number)])
-        output = self.run(args).stdout
+        with self.run(args) as p:
+            output = p.stdout
         return json.loads(output)
 
-    def repo_status(self):
-        output = self.run(["repo", "view", "--json", ",".join(REPO_FIELDS)]).stdout
+    def repo_status(self) -> dict:
+        with self.run(["repo", "view", "--json", ",".join(REPO_FIELDS)]) as p:
+            output = p.stdout
         return json.loads(output)

--- a/src/gh_worktree/logger.py
+++ b/src/gh_worktree/logger.py
@@ -2,6 +2,7 @@
 
 import logging
 import sys
+from logging.handlers import RotatingFileHandler
 from pathlib import Path
 
 # ANSI color codes
@@ -14,27 +15,25 @@ COLORS = {
     "cyan": "\033[96m",
     "reset": "\033[0m",
 }
-
-# Custom log level for command output
-COMMAND_OUTPUT = logging.INFO - 1
-logging.addLevelName(COMMAND_OUTPUT, "COMMAND_OUTPUT")
+MAX_LOG_SIZE = 10 * 1024 * 1024
+LOG_BACKUP = 5
 
 
 class ColorFormatter(logging.Formatter):
     """Formatter that applies colors based on log level or explicit color."""
 
     LEVEL_COLORS = {
-        logging.DEBUG: COLORS["cyan"],
-        COMMAND_OUTPUT: COLORS["blue"],
-        logging.INFO: COLORS["green"],
+        logging.DEBUG: COLORS["blue"],
         logging.WARNING: COLORS["yellow"],
         logging.ERROR: COLORS["red"],
-        logging.CRITICAL: COLORS["magenta"],
+        logging.CRITICAL: COLORS["red"],
     }
 
-    def __init__(self, fmt: str, use_color: bool = True):
+    def __init__(self, fmt: str, use_color: bool = True, base_logger_name: str | None = None):
         super().__init__(fmt)
         self.use_color = use_color
+        self.base_logger_name = base_logger_name
+        self.user_dir = Path("~").expanduser()
 
     def format(self, record: logging.LogRecord) -> str:
         # Use explicit color from extra if provided, otherwise use level-based color
@@ -44,17 +43,20 @@ class ColorFormatter(logging.Formatter):
         else:
             color_code = self.LEVEL_COLORS.get(record.levelno, COLORS["reset"])
 
-        message = super().format(record)
+        message = super().format(record).replace(f"{self.user_dir}/", "~/")
+        if self.base_logger_name and not record.name.startswith(self.base_logger_name):
+            message = f"{record.name} | {message}"
         if self.use_color and color_code:
             return f"{color_code}{message}{COLORS['reset']}"
         return message
 
 
 def setup_logger(
-    name: str = "gh-worktree",
+    name: str,
     log_dir: Path | None = None,
     verbose: bool = False,
     debug_log_path: Path | None = None,
+    max_log_size: int = MAX_LOG_SIZE,
 ) -> logging.Logger:
     """
     Set up logging with console and file handlers.
@@ -63,21 +65,25 @@ def setup_logger(
     :param log_dir: Directory for log files (defaults to ~/.gh/worktree/logs)
     :param verbose: Enable debug logging with full subprocess output
     :param debug_log_path: Specific path for debug log file
+    :param max_log_size: Maximum size of log files in bytes
     :return: Configured logger
     """
-    logger = logging.getLogger(name)
-    logger.setLevel(logging.DEBUG if verbose else logging.INFO)
-    logger.handlers = []  # Clear existing handlers
+    logger_level = logging.DEBUG if verbose else logging.INFO
+    handlers: list[logging.Handler] = []
 
     # Console formatter - colored, no timestamp for user-facing output
     console_fmt = "%(message)s"
-    console_formatter = ColorFormatter(console_fmt, use_color=sys.stdout.isatty())
+    console_formatter = ColorFormatter(
+        console_fmt,
+        use_color=sys.stdout.isatty(),
+        base_logger_name=name,
+    )
 
     # Console handler
     console_handler = logging.StreamHandler(sys.stdout)
     console_handler.setLevel(logging.INFO)
     console_handler.setFormatter(console_formatter)
-    logger.addHandler(console_handler)
+    handlers.append(console_handler)
 
     # File handlers (if log_dir provided)
     if log_dir:
@@ -85,57 +91,41 @@ def setup_logger(
 
         # Default log file - timestamps and commands
         default_log_file = log_dir / "gh-worktree.log"
-        file_fmt = "%(asctime)s - %(levelname)s - %(message)s"
+        file_fmt = "%(asctime)s [%(levelname)s] %(name)s | %(message)s"
         file_formatter = logging.Formatter(file_fmt, datefmt="%Y-%m-%d %H:%M:%S")
 
-        file_handler = logging.FileHandler(default_log_file, encoding="utf-8")
+        file_handler = RotatingFileHandler(
+            default_log_file, maxBytes=max_log_size, backupCount=LOG_BACKUP, encoding="utf-8"
+        )
         file_handler.setLevel(logging.DEBUG)
         file_handler.setFormatter(file_formatter)
-        logger.addHandler(file_handler)
+        handlers.append(file_handler)
 
         # Debug log file (if verbose or debug_log_path specified)
         if verbose or debug_log_path:
             debug_file = debug_log_path or (log_dir / "gh-worktree-debug.log")
             debug_formatter = logging.Formatter(
-                "%(asctime)s - %(levelname)s - %(name)s - %(message)s",
+                "%(asctime)s [%(levelname)s] %(name)s | %(message)s",
                 datefmt="%Y-%m-%d %H:%M:%S",
             )
 
-            debug_handler = logging.FileHandler(debug_file, encoding="utf-8")
+            debug_handler = RotatingFileHandler(
+                debug_file, maxBytes=max_log_size, backupCount=LOG_BACKUP, encoding="utf-8"
+            )
             debug_handler.setLevel(logging.DEBUG)
             debug_handler.setFormatter(debug_formatter)
-            logger.addHandler(debug_handler)
+            handlers.append(debug_handler)
 
             # Also log command output to debug file
             console_handler.setLevel(logging.DEBUG)
 
+    logging.basicConfig(
+        level=logger_level,
+        handlers=handlers,
+        force=True,
+    )
+
+    logger = logging.getLogger(name)
+    logger.setLevel(logger_level)
+
     return logger
-
-
-def get_logger(name: str = "gh-worktree") -> logging.Logger:
-    """Get an existing logger by name."""
-    return logging.getLogger(name)
-
-
-def log_command(
-    logger: logging.Logger,
-    command: list[str],
-    color: str | None = None,
-    output: str | None = None,
-):
-    """
-    Log a command being executed with optional color and output.
-
-    :param logger: Logger instance
-    :param command: Command list to log
-    :param color: Color to use for the command output
-    :param output: Optional command output to log at COMMAND_OUTPUT level
-    """
-    import shlex
-
-    color = color or "blue"
-    logger.info(f"Executing: {shlex.join(command)}", extra={"color": color})
-
-    if output:
-        for line in output.splitlines():
-            logger.log(COMMAND_OUTPUT, line, extra={"color": color})

--- a/src/gh_worktree/operator.py
+++ b/src/gh_worktree/operator.py
@@ -12,7 +12,8 @@ class RuntimeOperator:
 
     def __init__(self, context: Context, logger: logging.Logger):
         self.context = context
-        self.logger = logger
+        module_name = self.__class__.__module__.split(".")[-1]
+        self.logger = logger.getChild(module_name)
 
 
 class ConfigOperator(RuntimeOperator):

--- a/src/gh_worktree/runtime.py
+++ b/src/gh_worktree/runtime.py
@@ -20,7 +20,7 @@ class Runtime:
 
         log_dir = self.context.global_config_dir / "logs"
         logger = setup_logger(
-            name=name,
+            name,
             log_dir=log_dir,
             verbose=verbose,
         )

--- a/src/gh_worktree/subprocess.py
+++ b/src/gh_worktree/subprocess.py
@@ -1,32 +1,38 @@
+import logging
 import queue
 import random
 import shlex
 import subprocess
 import threading
 import time
-from collections.abc import Iterator
-from contextlib import ContextDecorator
+from collections.abc import Generator, Iterator
+from contextlib import ContextDecorator, contextmanager
 from pathlib import Path
+from subprocess import CompletedProcess
+from typing import Any
 
-from gh_worktree.logger import COMMAND_OUTPUT
 from gh_worktree.operator import RuntimeOperator
 
 # These are the allowed colors for command output, to avoid conflict with red/yellow errors/warnings
 ALLOWED_COLORS = ["green", "blue", "magenta", "cyan"]
 
 
-def _log_prefix(command: list[str]) -> str:
+def _log_name(command: list[str]) -> str:
     """
     Returns a prefix string for visibility, via logging, into the command being executed
     :param command: The command list to be executed
     :return: A string for prefixing log messages
     """
-    command_prefix = command[:2]
-    command_script_path = Path(command_prefix[0])
+    command_prefix = command[0]
+    command_script_path = Path(command_prefix)
     if command_script_path.exists():
-        command_prefix[0] = command_script_path.name
+        command_prefix = (
+            f"{command_script_path.name}.{command[1]}"
+            if len(command) > 1
+            else command_script_path.name
+        )
 
-    return shlex.join(command_prefix)
+    return command_prefix
 
 
 def _output_thread(process: subprocess.Popen) -> tuple[queue.Queue[str], threading.Thread]:
@@ -83,6 +89,12 @@ class SubprocessOperator(RuntimeOperator):
     command_name: str | None = None
     """The name of the command being executed, prepended to the command list"""
 
+    def _get_command_logger(self, command: list[str]) -> logging.Logger:
+        """Get a dedicated logger for logging command output"""
+        if self.command_name:
+            return logging.getLogger(self.command_name).getChild(_log_name(command))
+        return logging.getLogger(_log_name(command))
+
     def stream_exec(self, command: list[str], cwd: str | Path | None = None) -> int:
         """
         Executes a command in a subprocess and streams its output to stdout.
@@ -90,8 +102,11 @@ class SubprocessOperator(RuntimeOperator):
         :param cwd: The working directory to execute the command in
         :return: The exit code of the process
         """
+        logger = self._get_command_logger(command)
+
         if self.command_name:
             command = [self.command_name, *command]
+
         process = subprocess.Popen(
             command,
             stdout=subprocess.PIPE,
@@ -106,6 +121,7 @@ class SubprocessOperator(RuntimeOperator):
         try:
             color = ALLOWED_COLORS[process.pid % len(ALLOWED_COLORS)]
             self.logger.info(f"Executing: {shlex.join(command)}", extra={"color": color})
+            logger.debug(f"START: {shlex.join(command)}", extra={"color": color})
 
             while True:
                 remaining = deadline - time.monotonic()
@@ -124,9 +140,8 @@ class SubprocessOperator(RuntimeOperator):
                         break
                     continue
 
-                self.logger.log(
-                    COMMAND_OUTPUT,
-                    f"{_log_prefix(command)} | {line.rstrip()}",
+                logger.debug(
+                    line.rstrip(),
                     extra={"color": color},
                 )
 
@@ -139,41 +154,61 @@ class SubprocessOperator(RuntimeOperator):
             if process.stdout and hasattr(process.stdout, "close"):
                 process.stdout.close()
             reader_thread.join(timeout=0.5)
+            logger.debug(
+                f"END: {shlex.join(command)} ({process.returncode})", extra={"color": color}
+            )
 
         return process.returncode
 
-    @random_color
-    def run(self, command: list[str], cwd: str | Path | None = None) -> subprocess.CompletedProcess:
+    @contextmanager
+    def run(
+        self, command: list[str], cwd: str | Path | None = None
+    ) -> Generator[CompletedProcess, Any, None]:
         """
         Executes a command in a subprocess and returns the completed process
         :param command: The command to execute as a list of strings
         :param cwd: The working directory to execute the command in
         """
+        logger = self._get_command_logger(command)
         if self.command_name:
             command = [self.command_name, *command]
 
-        self.logger.info(f"Executing: {shlex.join(command)}", extra={"color": random_color.color})
+        with random_color:
+            self.logger.info(
+                f"Executing: {shlex.join(command)}", extra={"color": random_color.color}
+            )
+            logger.debug(f"START: {shlex.join(command)}", extra={"color": random_color.color})
+            process = None
 
-        return subprocess.run(
-            command,
-            capture_output=True,
-            text=True,
-            check=True,
-            timeout=self.wait_time,
-            cwd=cwd or self.context.cwd,
-        )
+            try:
+                process = subprocess.run(
+                    command,
+                    capture_output=True,
+                    text=True,
+                    check=True,
+                    timeout=self.wait_time,
+                    cwd=cwd or self.context.cwd,
+                )
+                yield process
+            finally:
+                logger.debug(
+                    f"END: {shlex.join(command)} ({getattr(process, 'returncode', None)})",
+                    extra={"color": random_color.color},
+                )
 
-    @random_color
     def iter_output(self, command: list[str], cwd: str | Path | None = None) -> Iterator[str]:
         """
         Executes a command in a subprocess and iterates its output after completion
         :param command: The command to execute as a list of strings
         :param cwd: The working directory to execute the command in
         """
-        for line in self.run(command, cwd=cwd).stdout.splitlines():
-            self.logger.log(
-                COMMAND_OUTPUT,
-                f"{_log_prefix(command)} | {line}",
-                extra={"color": random_color.color},
-            )
-            yield line
+        with random_color:
+            logger = self._get_command_logger(command)
+
+            with self.run(command, cwd=cwd) as process:
+                for line in process.stdout.splitlines():
+                    logger.debug(
+                        line.rstrip(),
+                        extra={"color": random_color.color},
+                    )
+                    yield line

--- a/tests/test_gh.py
+++ b/tests/test_gh.py
@@ -17,9 +17,8 @@ class GithubCLITestCase(TestCase):
     @mock.patch("gh_worktree.gh.SubprocessOperator.run")
     def test_pr_status__calls_gh_and_parses_json(self, mock_run):
         payload = {"number": 123, "title": "Example"}
-        mock_run.return_value = mock.Mock(
-            spec=subprocess.CompletedProcess, stdout=json.dumps(payload)
-        )
+        process = mock.MagicMock(spec=subprocess.CompletedProcess, stdout=json.dumps(payload))
+        mock_run.return_value.__enter__.return_value = process
 
         result = self.gh.pr_status(123)
         self.assertEqual(result, payload)
@@ -28,9 +27,8 @@ class GithubCLITestCase(TestCase):
     @mock.patch("gh_worktree.gh.SubprocessOperator.run")
     def test_pr_status__with_owner_repo(self, mock_run):
         payload = {"number": 123, "title": "Example"}
-        mock_run.return_value = mock.Mock(
-            spec=subprocess.CompletedProcess, stdout=json.dumps(payload)
-        )
+        process = mock.MagicMock(spec=subprocess.CompletedProcess, stdout=json.dumps(payload))
+        mock_run.return_value.__enter__.return_value = process
 
         result = self.gh.pr_status(123, owner_repo="me/repo")
         self.assertEqual(result, payload)
@@ -41,9 +39,8 @@ class GithubCLITestCase(TestCase):
     @mock.patch("gh_worktree.gh.SubprocessOperator.run")
     def test_repo_status__calls_gh_and_parses_json(self, mock_run):
         payload = {"name": "repo", "owner": "me"}
-        mock_run.return_value = mock.Mock(
-            spec=subprocess.CompletedProcess, stdout=json.dumps(payload)
-        )
+        process = mock.MagicMock(spec=subprocess.CompletedProcess, stdout=json.dumps(payload))
+        mock_run.return_value.__enter__.return_value = process
 
         result = self.gh.repo_status()
         self.assertEqual(result, payload)

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -1,0 +1,42 @@
+import logging
+from unittest import TestCase
+
+from gh_worktree.logger import ColorFormatter
+
+
+class ColorFormatterTestCase(TestCase):
+    def test_does_not_prefix_message_for_base_logger_namespace(self):
+        formatter = ColorFormatter(
+            "%(message)s",
+            use_color=False,
+            base_logger_name="gh_worktree",
+        )
+        record = logging.LogRecord(
+            name="gh_worktree.gh",
+            level=logging.INFO,
+            pathname=__file__,
+            lineno=1,
+            msg="hello",
+            args=(),
+            exc_info=None,
+        )
+
+        self.assertEqual(formatter.format(record), "hello")
+
+    def test_prefixes_message_for_external_logger(self):
+        formatter = ColorFormatter(
+            "%(message)s",
+            use_color=False,
+            base_logger_name="gh_worktree",
+        )
+        record = logging.LogRecord(
+            name="urllib3.connectionpool",
+            level=logging.INFO,
+            pathname=__file__,
+            lineno=1,
+            msg="hello",
+            args=(),
+            exc_info=None,
+        )
+
+        self.assertEqual(formatter.format(record), "urllib3.connectionpool | hello")

--- a/tests/test_operator.py
+++ b/tests/test_operator.py
@@ -1,0 +1,29 @@
+from pathlib import Path
+from types import SimpleNamespace
+from unittest import TestCase
+
+from gh_worktree.gh import GithubCLI
+from gh_worktree.git import GitCLI
+from gh_worktree.logger import setup_logger
+from gh_worktree.templates import Templates
+
+
+class RuntimeOperatorLoggerTestCase(TestCase):
+    def setUp(self):
+        self.context = SimpleNamespace(
+            cwd=Path("/repo"),
+            get_global_config=lambda: SimpleNamespace(allowed_envvars=[]),
+        )
+        self.logger = setup_logger("test")
+
+    def test_gh_operator_uses_module_child_logger(self):
+        cli = GithubCLI(self.context, self.logger)
+        self.assertEqual(cli.logger.name, "test.gh")
+
+    def test_git_operator_uses_module_child_logger(self):
+        cli = GitCLI(self.context, self.logger)
+        self.assertEqual(cli.logger.name, "test.git")
+
+    def test_templates_operator_uses_module_child_logger(self):
+        templates = Templates(self.context, self.logger)
+        self.assertEqual(templates.logger.name, "test.templates")

--- a/tests/test_subprocess.py
+++ b/tests/test_subprocess.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from unittest import TestCase, mock
 from unittest.mock import MagicMock, Mock
 
-from gh_worktree.subprocess import SubprocessOperator, _log_prefix
+from gh_worktree.subprocess import SubprocessOperator, _log_name
 
 
 class _SubprocessOperator(SubprocessOperator):
@@ -20,7 +20,14 @@ class SubprocessOperatorTestCase(TestCase):
         self.tmp_path = Path(self.tmp_dir.name)
         self.context = Mock()
         self.context.cwd = self.tmp_path
+        logging_patch = mock.patch("gh_worktree.subprocess.logging")
+        self.addCleanup(logging_patch.stop)
+        logging_mock = logging_patch.start()
         self.logger = Mock()
+        self.child_logger = Mock()
+        self.command_logger = logging_mock.getLogger.return_value
+        self.child_command_logger = self.command_logger.getChild.return_value
+        self.logger.getChild.return_value = self.child_logger
         self.operator = _SubprocessOperator(self.context, self.logger)
 
     def tearDown(self):
@@ -49,10 +56,21 @@ class SubprocessOperatorTestCase(TestCase):
         )
 
         self.assertEqual(exit_code, 0)
-        self.logger.info.assert_any_call(
+        self.logger.getChild.assert_called_once_with("test_subprocess")
+        self.child_logger.info.assert_any_call(
             f"Executing: {shlex.join(expected_command)}", extra=mock.ANY
         )
-        self.assertEqual(self.logger.log.call_count, 2)
+        self.assertEqual(self.child_command_logger.debug.call_count, 4)
+        self.assertEqual(
+            self.child_command_logger.debug.call_args_list[0][0][0],
+            "START: test_command do-something",
+        )
+        self.assertEqual(self.child_command_logger.debug.call_args_list[1][0][0], "line1")
+        self.assertEqual(self.child_command_logger.debug.call_args_list[2][0][0], "line2")
+        self.assertEqual(
+            self.child_command_logger.debug.call_args_list[3][0][0],
+            "END: test_command do-something (0)",
+        )
 
     @mock.patch("gh_worktree.subprocess.subprocess.Popen")
     def test_stream_exec__timeout_kills_process(self, mock_popen):
@@ -71,11 +89,12 @@ class SubprocessOperatorTestCase(TestCase):
 
     @mock.patch("gh_worktree.subprocess.subprocess.run")
     def test_run(self, mock_run):
-        result_mock = Mock(spec=subprocess.CompletedProcess, stdout="line1\nline2")
+        result_mock = Mock(spec=subprocess.CompletedProcess, stdout="line1\nline2", returncode=0)
         mock_run.return_value = result_mock
 
         command = ["get-data"]
-        output = self.operator.run(command)
+        with self.operator.run(command) as output:
+            self.assertEqual(output, result_mock)
 
         expected_command = ["test_command", "get-data"]
         mock_run.assert_called_once_with(
@@ -86,13 +105,19 @@ class SubprocessOperatorTestCase(TestCase):
             timeout=60,
             cwd=self.tmp_path,
         )
-
-        self.assertEqual(output, result_mock)
+        self.assertEqual(self.child_command_logger.debug.call_count, 2)
+        self.assertEqual(
+            self.child_command_logger.debug.call_args_list[0][0][0],
+            "START: test_command get-data",
+        )
+        self.assertEqual(
+            self.child_command_logger.debug.call_args_list[1][0][0],
+            "END: test_command get-data (0)",
+        )
 
     @mock.patch("gh_worktree.subprocess.subprocess.run")
     def test_iter_output(self, mock_run):
-        result_mock = Mock()
-        result_mock.stdout = "line1\nline2"
+        result_mock = Mock(spec=subprocess.CompletedProcess, stdout="line1\nline2", returncode=0)
         mock_run.return_value = result_mock
 
         command = ["get-data"]
@@ -109,18 +134,27 @@ class SubprocessOperatorTestCase(TestCase):
         )
 
         self.assertEqual(output, ["line1", "line2"])
-        self.logger.info.assert_called_once()
-        self.assertEqual(self.logger.log.call_count, 2)
+        self.child_logger.info.assert_called_once()
+        self.assertEqual(self.child_command_logger.debug.call_count, 4)
+        self.assertEqual(
+            self.child_command_logger.debug.call_args_list[0][0][0], "START: test_command get-data"
+        )
+        self.assertEqual(self.child_command_logger.debug.call_args_list[1][0][0], "line1")
+        self.assertEqual(self.child_command_logger.debug.call_args_list[2][0][0], "line2")
+        self.assertEqual(
+            self.child_command_logger.debug.call_args_list[3][0][0],
+            "END: test_command get-data (0)",
+        )
 
 
-class LogPrefixTestCase(TestCase):
+class LogNameTestCase(TestCase):
     def test_basic(self):
-        self.assertEqual(_log_prefix(["git", "status"]), "git status")
+        self.assertEqual(_log_name(["git", "status"]), "git")
 
     def test_script_path(self):
         with tempfile.NamedTemporaryFile() as tmp:
             script_path = Path(tmp.name)
-            self.assertEqual(_log_prefix([str(script_path), "run"]), f"{script_path.name} run")
+            self.assertEqual(_log_name([str(script_path), "run"]), f"{script_path.name}.run")
 
     def test_arg_limit(self):
-        self.assertEqual(_log_prefix(["git", "diff", "--", "path/to/file"]), "git diff")
+        self.assertEqual(_log_name(["git", "diff", "--", "path/to/file"]), "git")

--- a/uv.lock
+++ b/uv.lock
@@ -3,7 +3,7 @@ revision = 3
 requires-python = ">=3.10"
 
 [options]
-exclude-newer = "2026-04-11T15:53:58.518447459Z"
+exclude-newer = "2026-04-13T00:24:15.537628654Z"
 exclude-newer-span = "P7D"
 
 [[package]]
@@ -50,7 +50,7 @@ wheels = [
 
 [[package]]
 name = "gh-worktree"
-version = "0.3.2"
+version = "0.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "fire" },


### PR DESCRIPTION
## Summary
- Removes `COMMAND_OUTPUT` level and makes those logs simply `DEBUG`
- Changes `SubprocessOperator.run` to be a context manager
- Logs subprocess with command specific name, e.g. `git fetch origin` -> `2026-04-19 17:05:12 [DEBUG] git.fetch | START: git fetch origin`
- Sets global default logging configuration
- Removes unused logging functions
- Implements rotating file handler for log files
- Bumps version to 0.4.0