### PR TITLE
Add command for pruning worktrees

### DIFF
--- a/scripts/integration_test.sh
+++ b/scripts/integration_test.sh
@@ -146,4 +146,22 @@ if [ -d "for-integration" ]; then
 fi
 echo "PASS: All worktrees removed"
 
+# Test 8: Prune - remove worktrees for merged branches
+echo "[TEST 8] Pruning worktrees..."
+uv run treefort checkout 3
+
+assert_dir_exists "project-rename"
+cd project-rename
+rm -rf AGENTS.md .aiassistant/ .gemini/
+cd ..
+
+uv run treefort prune --yes
+
+if [ -d "project-rename" ]; then
+    echo "FAIL: project-rename/ still exists after prune"
+    exit 1
+fi
+
+echo "PASS: All worktrees pruned"
+
 echo "=== All Integration Tests Passed ==="

--- a/src/treefort/commands/prune.py
+++ b/src/treefort/commands/prune.py
@@ -1,0 +1,132 @@
+from pathlib import Path
+
+from treefort.command import Command
+from treefort.errors import CommandError
+from treefort.hooks import Hook
+from treefort.utils import normalize_worktree_name
+
+
+class PruneCommand(Command):
+    """Prune worktrees whose associated PRs have been merged"""
+
+    _name = "prune"
+
+    def __call__(self, force: bool = False, yes: bool = False):
+        """
+        Prune worktrees whose associated PRs have been merged.
+
+        This command identifies worktrees linked to merged PRs and removes
+        both the worktree directory and the local Git branch.
+
+        Examples:
+            treefort prune
+            treefort prune --yes
+            treefort prune --force --yes
+
+        :param force: Whether to force the removal of the worktree and branch,
+            bypassing git safety checks
+        :param yes: Perform any action automatically without asking (execute new or modified hooks)
+        """
+        self._context.assert_within_project()
+
+        pruned_count = 0
+        failed_count = 0
+
+        for worktree_name, branch_name in self._iter_worktrees():
+            if not yes:
+                response = input(
+                    f"Remove worktree '{worktree_name}' and branch '{branch_name}'? (y/N): "
+                )
+                if response.lower() != "y":
+                    self._logger.info(f"Skipping '{worktree_name}'")
+                    continue
+
+            if self._do_prune(worktree_name, branch_name, force, yes):
+                pruned_count += 1
+            else:
+                failed_count += 1
+
+        if pruned_count == 0 and failed_count == 0:
+            self._logger.info("No merged PR worktrees found to prune.")
+        else:
+            self._logger.info(f"Pruning complete: {pruned_count} pruned, {failed_count} failed.")
+
+    def _iter_worktrees(self):
+        """
+        Filter worktrees and search for matching PRs, yield candidates for pruning.
+        """
+        project_dir = self._context.project_dir
+        config = self._context.get_config()
+
+        worktrees = self._runtime.git.list_worktrees()
+
+        for wt in worktrees:
+            if wt.get("is_bare") or Path(wt["path"]).resolve() == project_dir.resolve():
+                continue
+
+            branch_ref = wt.get("branch")
+            if not branch_ref or not branch_ref.startswith("refs/heads/"):
+                continue
+
+            branch_name = branch_ref.removeprefix("refs/heads/")
+            worktree_name = Path(wt["path"]).name
+
+            pr_infos = self._runtime.gh.merged_pr_by_head(
+                branch_name, owner_repo=f"{config.owner}/{config.name}"
+            )
+
+            if not pr_infos:
+                continue
+
+            # Safety check: ensure local branch head matches the merged PR head
+            try:
+                local_head = self._runtime.git.get_branch_head(branch_name)
+            except CommandError as e:
+                self._logger.warning(f"Skipping '{worktree_name}': could not get branch head ({e})")
+                continue
+
+            pr_info = next((_pr for _pr in pr_infos if _pr.get("headRefOid") == local_head), None)
+
+            if not pr_info:
+                pr_heads = [pr["headRefOid"][:8] for pr in pr_infos if pr.get("headRefOid")]
+                self._logger.warning(
+                    f"Skipping '{worktree_name}': local branch head ({local_head[:8]}) does not "
+                    f"match any merged PR head(s) ({','.join(pr_heads)}). "
+                    "The branch may have been reused."
+                )
+                continue
+
+            self._logger.info(f"Found merged PR for worktree '{worktree_name}':")
+            self._logger.info(f"  PR #{pr_info['number']}: {pr_info['title']}")
+            self._logger.info(f"  URL: {pr_info['url']}")
+
+            yield worktree_name, branch_name
+
+    def _do_prune(self, worktree_name: str, branch_name: str, force: bool, yes: bool):
+        """
+        Executes the prune operation, firing the hooks before and after.
+        """
+        project_dir = self._context.project_dir
+
+        try:
+            normalized_name = normalize_worktree_name(worktree_name)
+            with self._context.use(project_dir):
+                self._runtime.hooks.fire(
+                    Hook.pre_remove, worktree_name, normalized_name, bypass_allowlist=yes
+                )
+
+                self._runtime.git.remove_worktree(worktree_name, force=force)
+                try:
+                    self._runtime.git.delete_branch(branch_name, force=force)
+                except CommandError as e:
+                    self._logger.warning(f"Failed to delete branch '{branch_name}': {e}")
+
+                self._runtime.hooks.fire(
+                    Hook.post_remove, worktree_name, normalized_name, bypass_allowlist=yes
+                )
+
+            self._logger.info(f"Successfully pruned '{worktree_name}'")
+            return True
+        except CommandError as e:
+            self._logger.error(f"Failed to prune '{worktree_name}': {e}")
+            return False

--- a/src/treefort/commands/remove.py
+++ b/src/treefort/commands/remove.py
@@ -1,5 +1,5 @@
 from treefort.command import Command
-from treefort.errors import WorktreeNotFoundError
+from treefort.errors import CommandError, WorktreeNotFoundError
 from treefort.hooks import Hook
 from treefort.utils import normalize_worktree_name
 
@@ -10,7 +10,13 @@ class RemoveCommand(Command):
     _name = "remove"
     _aliases = ["rm"]
 
-    def __call__(self, worktree_name: str, force: bool = False, yes: bool = False):
+    def __call__(
+        self,
+        worktree_name: str,
+        force: bool = False,
+        yes: bool = False,
+        delete_branch: bool = False,
+    ):
         """
         Remove a worktree from the current project that was added with `create` or `checkout`.
 
@@ -20,11 +26,14 @@ class RemoveCommand(Command):
         Examples:
             treefort remove testing-create
             treefort remove testing-create --force
+            treefort remove testing-create --delete-branch
 
         :param worktree_name: The name of the worktree to remove
         :param force: Whether to force the removal of the worktree, if it's unmerged
-        :param yes: Perform any action automatically without asking (execute new or modified hooks)
-        :type yes: bool
+        :param yes: Perform any action automatically without asking
+            (execute new or modified hooks)
+        :param delete_branch: Whether to also delete the local Git branch
+            associated with the worktree (branch name matches worktree name)
         """
         project_dir = self._context.project_dir
         if not (project_dir / worktree_name).exists():
@@ -37,6 +46,13 @@ class RemoveCommand(Command):
                 Hook.pre_remove, worktree_name, normalized_name, bypass_allowlist=yes
             )
             self._runtime.git.remove_worktree(worktree_name, force=force)
+
+            if delete_branch:
+                try:
+                    self._runtime.git.delete_branch(worktree_name, force=force)
+                except CommandError as e:
+                    self._logger.warning(f"Failed to delete branch '{worktree_name}': {e}")
+
             self._runtime.hooks.fire(
                 Hook.post_remove, worktree_name, normalized_name, bypass_allowlist=yes
             )

--- a/src/treefort/gh.py
+++ b/src/treefort/gh.py
@@ -7,6 +7,7 @@ PR_FIELDS = [
     "author",
     "baseRefName",
     "headRefName",
+    "headRefOid",
     "headRepository",
     "headRepositoryOwner",
     "state",
@@ -38,3 +39,27 @@ class GithubCLI(SubprocessOperator):
         with self.run(["repo", "view", "--json", ",".join(REPO_FIELDS)]) as p:
             output = p.stdout
         return json.loads(output)
+
+    def merged_pr_by_head(self, head_ref_name: str, owner_repo: str | None = None) -> list[dict]:
+        """Get merged PR info for a given head ref name"""
+        args = [
+            "pr",
+            "list",
+            "--head",
+            head_ref_name,
+            "--state",
+            "merged",
+            "--json",
+            ",".join(PR_FIELDS),
+        ]
+        if owner_repo:
+            args.extend(["--repo", owner_repo])
+        try:
+            with self.run(args) as p:
+                output = p.stdout
+            prs = json.loads(output)
+            if prs:
+                return prs
+        except Exception:
+            pass
+        return []

--- a/src/treefort/git.py
+++ b/src/treefort/git.py
@@ -69,3 +69,27 @@ class GitCLI(SubprocessOperator):
             args.append("--force")
         args.extend(["--", name])
         self.stream_exec(args)
+
+    def list_worktrees(self) -> list[dict]:
+        """List all worktrees and their associated branches"""
+        worktrees = []
+        current_worktree = None
+        for line in self.iter_output(["worktree", "list", "--porcelain"]):
+            if line.startswith("worktree "):
+                current_worktree = {"path": line[9:], "branch": None, "is_bare": False}
+                worktrees.append(current_worktree)
+            elif line.startswith("branch ") and current_worktree:
+                current_worktree["branch"] = line[7:]
+            elif line == "bare" and current_worktree:
+                current_worktree["is_bare"] = True
+        return worktrees
+
+    def delete_branch(self, name: str, force: bool = False):
+        """Delete a local branch"""
+        args = ["branch", "-d" if not force else "-D", "--", name]
+        self.stream_exec(args)
+
+    def get_branch_head(self, branch_name: str) -> str:
+        """Get the HEAD commit SHA of a given branch"""
+        with self.run(["rev-parse", branch_name]) as p:
+            return p.stdout.strip()

--- a/src/treefort/main.py
+++ b/src/treefort/main.py
@@ -6,6 +6,7 @@ from treefort.commands.checkout import CheckoutCommand
 from treefort.commands.create import CreateCommand
 from treefort.commands.init import InitCommand
 from treefort.commands.install import InstallCommand
+from treefort.commands.prune import PruneCommand
 from treefort.commands.remove import RemoveCommand
 from treefort.errors import AliasConflictError
 from treefort.runtime import Runtime
@@ -31,6 +32,7 @@ class WorktreeCommands(Command):
         self._add(InitCommand(self._runtime))
         self._add(InstallCommand(self._runtime))
         self._add(RemoveCommand(self._runtime))
+        self._add(PruneCommand(self._runtime))
 
     def _add(self, command: Command):
         """

--- a/tests/commands/test_prune.py
+++ b/tests/commands/test_prune.py
@@ -1,0 +1,200 @@
+import tempfile
+from contextlib import contextmanager
+from pathlib import Path
+from types import SimpleNamespace
+from unittest import TestCase
+from unittest.mock import Mock, patch
+
+from treefort.commands.prune import PruneCommand
+from treefort.errors import CommandError
+from treefort.hooks import Hook
+
+
+class StubContext:
+    def __init__(self, project_dir, config):
+        self.project_dir = project_dir
+        self._config = config
+        self.assert_called = False
+
+    def assert_within_project(self):
+        self.assert_called = True
+
+    def get_config(self):
+        return self._config
+
+    @contextmanager
+    def use(self, cwd):
+        yield
+
+
+class PruneCommandTestCase(TestCase):
+    def setUp(self):
+        self.tmp_dir = tempfile.TemporaryDirectory()
+        self.tmp_path = Path(self.tmp_dir.name)
+        self.project_dir = self.tmp_path / "project"
+        self.project_dir.mkdir()
+
+        self.config = SimpleNamespace(owner="octo", name="repo")
+        self.context = StubContext(self.project_dir, self.config)
+
+        self.hooks = SimpleNamespace(fire=Mock())
+        self.git = SimpleNamespace(
+            list_worktrees=Mock(),
+            get_branch_head=Mock(),
+            remove_worktree=Mock(),
+            delete_branch=Mock(),
+        )
+        self.gh = SimpleNamespace(merged_pr_by_head=Mock())
+        self.logger = Mock()
+
+        self.runtime = SimpleNamespace(
+            context=self.context,
+            hooks=self.hooks,
+            git=self.git,
+            gh=self.gh,
+            logger=self.logger,
+        )
+        self.command = PruneCommand(self.runtime)
+
+    def tearDown(self):
+        self.tmp_dir.cleanup()
+
+    def test_call__no_worktrees_to_prune(self):
+        self.git.list_worktrees.return_value = [
+            {"path": str(self.project_dir), "branch": "refs/heads/main", "is_bare": False},
+            {"path": "/bare/repo.git", "branch": None, "is_bare": True},
+        ]
+
+        self.command()
+
+        self.assertTrue(self.context.assert_called)
+        self.logger.info.assert_any_call("No merged PR worktrees found to prune.")
+
+    def test_call__prunes_merged_worktree(self):
+        wt_path = str(self.project_dir / "feature-branch")
+        (self.project_dir / "feature-branch").mkdir()
+
+        self.git.list_worktrees.return_value = [
+            {"path": wt_path, "branch": "refs/heads/feature-branch", "is_bare": False},
+        ]
+        self.git.get_branch_head.return_value = "abc123def456"
+        self.gh.merged_pr_by_head.return_value = [
+            {
+                "number": 123,
+                "title": "Add awesome feature",
+                "url": "https://github.com/octo/repo/pull/123",
+                "headRefOid": "abc123def456",
+            }
+        ]
+
+        with patch("builtins.input", return_value="y"):
+            self.command()
+
+        self.git.remove_worktree.assert_called_once_with("feature-branch", force=False)
+        self.git.delete_branch.assert_called_once_with("feature-branch", force=False)
+        self.hooks.fire.assert_any_call(
+            Hook.pre_remove, "feature-branch", "feature-branch", bypass_allowlist=False
+        )
+        self.hooks.fire.assert_any_call(
+            Hook.post_remove, "feature-branch", "feature-branch", bypass_allowlist=False
+        )
+        self.logger.info.assert_any_call("Successfully pruned 'feature-branch'")
+
+    def test_call__skips_reused_branch(self):
+        wt_path = str(self.project_dir / "reused-branch")
+        (self.project_dir / "reused-branch").mkdir()
+
+        self.git.list_worktrees.return_value = [
+            {"path": wt_path, "branch": "refs/heads/reused-branch", "is_bare": False},
+        ]
+        self.git.get_branch_head.return_value = "newcommit1"
+        self.gh.merged_pr_by_head.return_value = [
+            {
+                "number": 100,
+                "title": "Old PR",
+                "url": "https://github.com/octo/repo/pull/100",
+                "headRefOid": "oldcommit1",
+            }
+        ]
+
+        self.command()
+
+        self.git.remove_worktree.assert_not_called()
+        self.logger.warning.assert_called()
+        warning_msg = str(self.logger.warning.call_args[0][0])
+        self.assertIn("does not match any merged PR head", warning_msg)
+
+    def test_call__skips_on_get_branch_head_error(self):
+        wt_path = str(self.project_dir / "error-branch")
+        (self.project_dir / "error-branch").mkdir()
+
+        self.git.list_worktrees.return_value = [
+            {"path": wt_path, "branch": "refs/heads/error-branch", "is_bare": False},
+        ]
+        self.git.get_branch_head.side_effect = CommandError("git failed")
+        self.gh.merged_pr_by_head.return_value = [{"number": 1}]
+
+        self.command()
+
+        self.git.remove_worktree.assert_not_called()
+        self.logger.warning.assert_called()
+
+    def test_call__yes_true_skips_prompt(self):
+        wt_path = str(self.project_dir / "auto-branch")
+        (self.project_dir / "auto-branch").mkdir()
+
+        self.git.list_worktrees.return_value = [
+            {"path": wt_path, "branch": "refs/heads/auto-branch", "is_bare": False},
+        ]
+        self.git.get_branch_head.return_value = "match123"
+        self.gh.merged_pr_by_head.return_value = [
+            {"number": 1, "title": "Auto", "url": "url", "headRefOid": "match123"}
+        ]
+
+        self.command(yes=True)
+
+        self.git.remove_worktree.assert_called_once()
+        self.hooks.fire.assert_any_call(
+            Hook.pre_remove, "auto-branch", "auto-branch", bypass_allowlist=True
+        )
+
+    def test_call__force_true_passed_to_git(self):
+        wt_path = str(self.project_dir / "force-branch")
+        (self.project_dir / "force-branch").mkdir()
+
+        self.git.list_worktrees.return_value = [
+            {"path": wt_path, "branch": "refs/heads/force-branch", "is_bare": False},
+        ]
+        self.git.get_branch_head.return_value = "match123"
+        self.gh.merged_pr_by_head.return_value = [
+            {"number": 1, "title": "Force", "url": "url", "headRefOid": "match123"}
+        ]
+
+        with patch("builtins.input", return_value="y"):
+            self.command(force=True)
+
+        self.git.remove_worktree.assert_called_once_with("force-branch", force=True)
+        self.git.delete_branch.assert_called_once_with("force-branch", force=True)
+
+    def test_call__handles_prune_failure_gracefully(self):
+        wt_path = str(self.project_dir / "fail-branch")
+        (self.project_dir / "fail-branch").mkdir()
+        wt_path2 = str(self.project_dir / "success-branch")
+        (self.project_dir / "success-branch").mkdir()
+
+        self.git.list_worktrees.return_value = [
+            {"path": wt_path, "branch": "refs/heads/fail-branch", "is_bare": False},
+            {"path": wt_path2, "branch": "refs/heads/success-branch", "is_bare": False},
+        ]
+        self.git.get_branch_head.return_value = "match123"
+        self.gh.merged_pr_by_head.return_value = [
+            {"number": 1, "title": "Test", "url": "url", "headRefOid": "match123"}
+        ]
+        self.git.remove_worktree.side_effect = [CommandError("locked"), None]
+
+        with patch("builtins.input", return_value="y"):
+            self.command()
+
+        self.logger.error.assert_called()
+        self.logger.info.assert_any_call("Successfully pruned 'success-branch'")
+        self.logger.info.assert_any_call("Pruning complete: 1 pruned, 1 failed.")

--- a/tests/commands/test_remove.py
+++ b/tests/commands/test_remove.py
@@ -47,13 +47,17 @@ class RemoveCommandTestCase(TestCase):
 
         context = StubContext(project_dir)
         hooks = SimpleNamespace(fire=Mock())
-        git = SimpleNamespace(remove_worktree=Mock())
+        git = SimpleNamespace(
+            remove_worktree=Mock(),
+            delete_branch=Mock(),
+        )
         runtime = SimpleNamespace(context=context, hooks=hooks, git=git)
 
         command = RemoveCommand(runtime)
-        command("feature", force=True)
+        command("feature", force=True, delete_branch=True)
 
         git.remove_worktree.assert_called_once_with("feature", force=True)
+        git.delete_branch.assert_called_once_with("feature", force=True)
         hooks.fire.assert_any_call(Hook.pre_remove, "feature", "feature", bypass_allowlist=False)
         hooks.fire.assert_any_call(Hook.post_remove, "feature", "feature", bypass_allowlist=False)
 

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -120,3 +120,16 @@ class GitCLITestCase(TestCase):
         self.mock_stream_exec.assert_called_with(
             ["worktree", "remove", "--force", "--", "old-tree"], cwd=None
         )
+
+    def test_get_branch_head(self):
+        run_patcher = mock.patch("treefort.git.SubprocessOperator.run")
+        mock_run = run_patcher.start()
+        self.addCleanup(run_patcher.stop)
+
+        mock_process = mock.MagicMock()
+        mock_process.stdout = "abc123def456\n"
+        mock_run.return_value.__enter__.return_value = mock_process
+
+        result = self.cli.get_branch_head("feature-branch")
+        mock_run.assert_called_once_with(["rev-parse", "feature-branch"])
+        self.assertEqual(result, "abc123def456")


### PR DESCRIPTION
## Summary
Adds command `prune` which can be used to prune worktrees. It works by searching the default configured Github repository for PRs with matching head branches that have been merged. It validates head commit of each matches before prompting the user to remove it. By default it also deletes the branch.

The `remove` command also has a new flag that enables optional removal of the worktree branch.